### PR TITLE
Document Nanobot architecture: skills system, not MCP

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,7 @@
 # Claude Context File
 
 > This file helps Claude understand the project and pick up where we left off.
+> **Multiple Claude agents work on this project in parallel** - check TODO.md before starting work.
 
 ## Project Overview
 
@@ -19,18 +20,70 @@
 
 > **IMPORTANT: See [TODO.md](TODO.md) for what to work on next**
 >
-> TODO.md is gitignored (local only) - it tracks our development work.
+> TODO.md is gitignored (local only) - it tracks our development work and task assignments.
+> **Always check TODO.md before starting work** to avoid duplicating effort.
 
 ### Development Approach
 We're building the software FIRST, then deploying to Mac Mini later:
 1. Build PWA (React app) - can develop/test locally
-2. Build MCP servers (Python) - can develop/test locally
+2. Build Nanobot skills & tools (Python) - can develop/test locally
 3. Create Docker Compose files - define the infrastructure
 4. Build custom Docker images - package our code
 5. Create setup scripts - automate deployment
 
 ### Blockers
 - Mac Mini hardware not yet arrived (but we can build software now!)
+
+## Critical: Nanobot Architecture
+
+> ⚠️ **The plan originally said "MCP-native" - this is incorrect.**
+
+**HKUDS/nanobot** (the one we're using) uses a **skills system**, not MCP:
+
+```
+Skills (SKILL.md)     →  Markdown files that TEACH the agent how to do things
+Tools (Python class)  →  Code that EXECUTES actions (shell, filesystem, web, etc.)
+```
+
+### Two Nanobot Projects Exist - We Use HKUDS
+
+| Project | What It Is | Our Choice |
+|---------|------------|------------|
+| **[HKUDS/nanobot](https://github.com/HKUDS/nanobot)** | Python, ~4k lines, WhatsApp/Telegram built-in | ✅ **Using this** |
+| [nanobot-ai/nanobot](https://github.com/nanobot-ai/nanobot) | Go-based MCP host, different project | ❌ Not using |
+
+### What's Built Into HKUDS/nanobot
+- ✅ WhatsApp integration (just configure, don't rebuild)
+- ✅ Telegram with voice transcription (Groq Whisper)
+- ✅ Cron scheduling
+- ✅ Basic memory system (`memory.py`)
+- ✅ Weather skill (already exists)
+- ❌ LiveKit/real-time voice (we need to add this)
+- ❌ Local Whisper STT (uses Groq API, we want local)
+
+### How to Extend Nanobot
+
+**For simple integrations** → Write a Skill (SKILL.md):
+```markdown
+---
+name: my_skill
+description: "What it does"
+metadata: {"nanobot":{"requires":{"bins":["curl"]}}}
+---
+# Instructions for the agent
+Use `curl` to call the API...
+```
+
+**For critical integrations** → Write a Tool (Python):
+```python
+class MyTool(Tool):
+    name = "my_tool"
+    description = "What it does"
+    parameters = { ... }  # JSON Schema
+
+    async def execute(self, **kwargs) -> str:
+        # Actual implementation
+```
 
 ## Project Structure
 
@@ -39,6 +92,7 @@ home-server/
 ├── CLAUDE.md              # This file - context for Claude
 ├── README.md              # User-facing quick start
 ├── HOMESERVER_PLAN.md     # Complete architecture & plan
+├── TODO.md                # Task tracking (gitignored, local only)
 ├── setup.sh               # All-in-one setup (calls scripts/)
 ├── scripts/               # Individual setup scripts
 │   ├── 01-homebrew.sh
@@ -77,7 +131,9 @@ home-server/
 | Alexa integration | haaska + AWS Lambda | Free vs £5/mo HA Cloud |
 | Cloud backup | Optional (user choice) | Cost reduction, user accepts risk |
 | Docker runtime | OrbStack | Optimized for Apple Silicon |
-| AI agent | Nanobot | Minimal codebase (~4k lines), auditable |
+| AI agent | HKUDS/nanobot | Minimal codebase (~4k lines), WhatsApp built-in |
+| Agent extensions | Skills + Python Tools | Skills for simple, Tools for critical |
+| Memory storage | PostgreSQL (Immich's DB) | Already in stack, has vector extensions |
 | Remote access | Tailscale | No port forwarding, works everywhere |
 | SSH | Optional | Not everyone runs headless |
 
@@ -101,38 +157,23 @@ bash scripts/01-homebrew.sh
 ls -la && git status
 ```
 
-## Open Design Questions
+## Design Decisions Made (2026-02-05)
 
-### AI Butler Memory & Personalization
-Need to design and implement:
+### Memory & Personalization - RESOLVED
 
-1. **User Memory** - Remember facts about each user
-   - Names, preferences, routines
-   - Past requests and outcomes
-   - "Ron prefers audiobooks at 1.2x speed"
+| Question | Answer |
+|----------|--------|
+| Does Nanobot have built-in memory? | Yes, basic `memory.py` - we extend it |
+| Memory storage? | PostgreSQL (Immich's DB, `butler` schema) |
+| How to inject user context? | Load soul config + facts into system prompt |
+| Where does soul config live? | PostgreSQL `butler.users` table |
 
-2. **Multi-User Support** - Already in plan, but needs:
-   - User identification (JWT token from app)
-   - Per-user conversation history
-   - Per-user preferences
+### Remaining Questions
 
-3. **Soul/Personality per User** - Custom behavior settings
-   - Formality level (casual vs professional)
-   - Verbosity (brief vs detailed)
-   - Humor, tone, interaction style
-   - Custom instructions ("always suggest audiobooks")
-
-4. **Memory Storage Options**
-   - SQLite (simple, local)
-   - PostgreSQL (if we want Immich's DB)
-   - Redis (fast, but volatile)
-   - JSON files (simplest, but doesn't scale)
-
-### Questions to Resolve
-- Does Nanobot have built-in memory/persistence?
-- How to inject user context into Claude system prompt?
-- Where does "soul" config live? (JSON file? DB?)
-- Voice identification vs app-based user identification?
+- [ ] How does Nanobot handle multi-user conversations?
+- [ ] Can we run multiple Nanobot instances (one per channel)?
+- [ ] Best way to share tools between voice agent and text agent?
+- [ ] Voice identification vs app-based user identification?
 
 ## Notes for Future Sessions
 
@@ -142,3 +183,5 @@ Need to design and implement:
 - SSH setup is OPTIONAL - some users manage Mac Mini directly
 - The Mac Mini hasn't arrived yet - we're in planning/prep phase
 - **Memory/personalization is important** - Butler should know users
+- **Check TODO.md first** - other agents may be working on related tasks
+- **Update TODO.md** when you start/finish work to avoid conflicts

--- a/HOMESERVER_PLAN.md
+++ b/HOMESERVER_PLAN.md
@@ -5,7 +5,9 @@
 > **Goal:** Self-hosted, privacy-focused media server with AI voice assistant + Alexa
 > **Hardware Cost:** ~£760 (Japan tax-free) vs ~£1,049 (UK) - **saving £289**
 > **Monthly Cost:** ~£7.21 (API + electricity) — backup optional, Alexa via free haaska
-> **Butler Engine:** [Nanobot](https://github.com/HKUDS/nanobot) (~4k lines, MCP-native)
+> **Butler Engine:** [Nanobot](https://github.com/HKUDS/nanobot) (~4k lines, skill-based)
+>
+> ⚠️ **Note (2026-02-05):** Nanobot uses a "skills" system (markdown instruction files), not MCP. Skills teach the agent how to use tools; the agent then calls built-in executors (shell, filesystem, web). Custom Python tools can also be registered. See TODO.md for details.
 
 ---
 
@@ -133,7 +135,7 @@ Ask at store: "このACアダプターは100-240V対応ですか？" (Does this 
 | Service | Homepage | Purpose | Run Method | RAM (Idle) | RAM (Peak) | Port |
 |---------|----------|---------|------------|------------|------------|------|
 | [**Nanobot**](https://github.com/HKUDS/nanobot) | [GitHub](https://github.com/HKUDS/nanobot) | Ultra-lightweight AI agent (~4k lines) | Docker container | 100MB | 300MB | 8100 |
-| Custom MCPs | Self-built | MCP servers for service integrations | Docker containers | ~50MB each | ~100MB each | Various |
+| Custom Skills/Tools | Self-built | Skills (markdown) + Tools (Python) for service integrations | Part of Nanobot | Included | Included | - |
 | [**APScheduler**](https://apscheduler.readthedocs.io/) | [Docs](https://apscheduler.readthedocs.io/) | Cron-style task scheduling | Part of Agent | Included | Included | - |
 
 > **Note:** The LLM (Claude) runs in the cloud to preserve local RAM. Voice processing (Whisper, Kokoro) runs locally for low latency.
@@ -551,9 +553,9 @@ RECENT CONTEXT:
 - 3 days ago: Asked about smart home heating schedule
 ```
 
-#### Memory MCP Server
+#### Memory Tools
 
-A custom MCP server handles memory operations:
+Custom Python tools extend Nanobot's built-in `memory.py` for memory operations:
 
 | Tool | Purpose |
 |------|---------|
@@ -651,7 +653,9 @@ A custom MCP server handles memory operations:
 - User settings & preferences
 - PWA install prompt
 
-### Integrations (Custom MCPs)
+### Integrations (Custom Skills & Tools)
+
+> **Note:** These are implemented as Nanobot skills (markdown instructions) or custom Python tools, not MCP servers. See TODO.md for implementation approach decisions.
 
 #### Read-Only Integrations
 


### PR DESCRIPTION
## Summary

- Clarify that HKUDS/nanobot uses a skills/tools system, not MCP as originally stated
- Add architectural guidance for parallel Claude agent collaboration
- Document the two Nanobot projects and which one we're using
- Update key architecture decisions with agent extension approach
- Mark previously unresolved questions as resolved (memory storage, soul config)

## Context

This research branch (`ron875/mcp-integrations`) investigated the Nanobot agent framework and discovered the plan's "MCP-native" claim was incorrect. HKUDS/nanobot uses markdown skills that teach agents + Python tools that execute actions. We've documented this for other agents working on the project.