### PR TITLE
Move tasks to GitHub Issues and add plan review workflow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,12 +18,25 @@ gh issue edit <number> --add-assignee @me
 git checkout -b ron875/issue-<number>-short-description
 ```
 
-### When Creating a PR
+### When Completing a Task
 
+**Before creating a PR, always:**
+
+1. **Review HOMESERVER_PLAN.md** — Does anything need updating based on what you learned?
+   - Incorrect assumptions? Fix them.
+   - New decisions made? Document them.
+   - Architecture changed? Update the diagrams/tables.
+
+2. **Update if needed** — Keep the plan accurate for future agents.
+
+3. **Create the PR:**
 ```bash
 # Reference the issue in PR body (auto-closes on merge)
 gh pr create --title "Build Home Assistant Tool" --body "Closes #4"
 ```
+
+> **Example:** We discovered Nanobot uses "skills" not MCP — we updated the plan.
+> **Example:** We decided to use PostgreSQL directly instead of memory.py — we updated the issue.
 
 ### Quick Commands
 ```bash
@@ -209,3 +222,4 @@ home-server/
 - **Always check `gh issue list` first** before starting work
 - **Claim issues with `gh issue edit --add-assignee @me`** to avoid conflicts
 - **Use `Closes #N` in PR body** to auto-close issues on merge
+- **Review HOMESERVER_PLAN.md before PR** — update if you learned something new

--- a/HOMESERVER_PLAN.md
+++ b/HOMESERVER_PLAN.md
@@ -555,7 +555,7 @@ RECENT CONTEXT:
 
 #### Memory Tools
 
-Custom Python tools extend Nanobot's built-in `memory.py` for memory operations:
+Custom Python tools interface directly with PostgreSQL (not Nanobot's built-in `memory.py`):
 
 | Tool | Purpose |
 |------|---------|


### PR DESCRIPTION
## Summary

- Created GitHub Issues #2-#12 for all development tasks (eliminates merge conflicts with parallel agents)
- Updated CLAUDE.md with task workflow: claim issues → work → review plan → create PR
- Added "When Completing a Task" section requiring HOMESERVER_PLAN.md review before PR
- Clarified memory system: PostgreSQL tools directly, not extending memory.py

## Why This Matters

GitHub Issues provides real-time task coordination without merge conflicts. Plan review ensures documentation stays accurate as we learn.