### PR TITLE
Add Home Assistant Tool (Python)

### DIFF
--- a/nanobot/tools/__init__.py
+++ b/nanobot/tools/__init__.py
@@ -4,9 +4,14 @@ These tools extend Nanobot's capabilities with home server integrations.
 """
 
 from .memory import RememberFactTool, RecallFactsTool, GetUserTool
+from .home_assistant import HomeAssistantTool, ListEntitiesByDomainTool
 
 __all__ = [
+    # Memory
     "RememberFactTool",
     "RecallFactsTool",
     "GetUserTool",
+    # Home Assistant
+    "HomeAssistantTool",
+    "ListEntitiesByDomainTool",
 ]

--- a/nanobot/tools/home_assistant.py
+++ b/nanobot/tools/home_assistant.py
@@ -1,0 +1,407 @@
+"""Home Assistant integration tool for Butler.
+
+This tool allows the agent to control smart home devices via
+Home Assistant's REST API, enabling voice and text-based home automation.
+
+Usage:
+    The tool is automatically registered with Nanobot when the container starts.
+    It requires HOME_ASSISTANT_URL and HOME_ASSISTANT_TOKEN environment variables.
+
+API Reference:
+    https://developers.home-assistant.io/docs/api/rest/
+"""
+
+from typing import Any
+import os
+import aiohttp
+
+
+class Tool:
+    """Base class for Nanobot tools (compatible interface)."""
+
+    @property
+    def name(self) -> str:
+        raise NotImplementedError
+
+    @property
+    def description(self) -> str:
+        raise NotImplementedError
+
+    @property
+    def parameters(self) -> dict[str, Any]:
+        raise NotImplementedError
+
+    async def execute(self, **kwargs: Any) -> str:
+        raise NotImplementedError
+
+    def to_schema(self) -> dict[str, Any]:
+        """Convert to OpenAI function schema format."""
+        return {
+            "type": "function",
+            "function": {
+                "name": self.name,
+                "description": self.description,
+                "parameters": self.parameters,
+            }
+        }
+
+
+class HomeAssistantTool(Tool):
+    """Control Home Assistant devices and services.
+
+    Supports turning devices on/off, getting device states,
+    and calling arbitrary Home Assistant services.
+    """
+
+    def __init__(
+        self,
+        base_url: str | None = None,
+        token: str | None = None,
+    ):
+        self.base_url = (base_url or os.environ.get("HOME_ASSISTANT_URL", "")).rstrip("/")
+        self.token = token or os.environ.get("HOME_ASSISTANT_TOKEN", "")
+
+    def _get_headers(self) -> dict[str, str]:
+        """Get HTTP headers for HA API requests."""
+        return {
+            "Authorization": f"Bearer {self.token}",
+            "Content-Type": "application/json",
+        }
+
+    @property
+    def name(self) -> str:
+        return "home_assistant"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Control smart home devices via Home Assistant. "
+            "Can turn devices on/off, check their current state, "
+            "or call any Home Assistant service (set brightness, play media, etc.)."
+        )
+
+    @property
+    def parameters(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "action": {
+                    "type": "string",
+                    "enum": ["turn_on", "turn_off", "toggle", "get_state", "call_service"],
+                    "description": (
+                        "Action to perform: "
+                        "turn_on/turn_off/toggle for simple control, "
+                        "get_state to check current state, "
+                        "call_service for advanced operations"
+                    )
+                },
+                "entity_id": {
+                    "type": "string",
+                    "description": (
+                        "The entity ID (e.g., 'light.living_room', 'switch.coffee_maker', "
+                        "'media_player.tv'). Required for all actions except call_service "
+                        "when targeting a domain-wide service."
+                    )
+                },
+                "domain": {
+                    "type": "string",
+                    "description": (
+                        "Service domain for call_service action (e.g., 'light', 'media_player'). "
+                        "If not specified, extracted from entity_id."
+                    )
+                },
+                "service": {
+                    "type": "string",
+                    "description": (
+                        "Service name for call_service action (e.g., 'turn_on', 'set_volume_level'). "
+                        "Required when action is 'call_service'."
+                    )
+                },
+                "service_data": {
+                    "type": "object",
+                    "description": (
+                        "Additional data for the service call (e.g., "
+                        "{'brightness': 128} for lights, {'volume_level': 0.5} for media). "
+                        "Entity_id is automatically included if provided."
+                    )
+                }
+            },
+            "required": ["action"]
+        }
+
+    async def execute(self, **kwargs: Any) -> str:
+        action = kwargs["action"]
+        entity_id = kwargs.get("entity_id")
+        domain = kwargs.get("domain")
+        service = kwargs.get("service")
+        service_data = kwargs.get("service_data", {})
+
+        if not self.base_url or not self.token:
+            return "Error: HOME_ASSISTANT_URL and HOME_ASSISTANT_TOKEN must be configured."
+
+        try:
+            if action == "get_state":
+                return await self._get_state(entity_id)
+            elif action in ("turn_on", "turn_off", "toggle"):
+                return await self._simple_action(action, entity_id, service_data)
+            elif action == "call_service":
+                return await self._call_service(domain, service, entity_id, service_data)
+            else:
+                return f"Error: Unknown action '{action}'"
+        except aiohttp.ClientError as e:
+            return f"Error connecting to Home Assistant: {e}"
+        except Exception as e:
+            return f"Error: {e}"
+
+    async def _get_state(self, entity_id: str | None) -> str:
+        """Get the current state of an entity or list all entities."""
+        async with aiohttp.ClientSession() as session:
+            if entity_id:
+                url = f"{self.base_url}/api/states/{entity_id}"
+                async with session.get(url, headers=self._get_headers()) as resp:
+                    if resp.status == 404:
+                        return f"Entity '{entity_id}' not found."
+                    if resp.status != 200:
+                        return f"Error: HTTP {resp.status}"
+
+                    data = await resp.json()
+                    return self._format_entity_state(data)
+            else:
+                # List all entities (summarized)
+                url = f"{self.base_url}/api/states"
+                async with session.get(url, headers=self._get_headers()) as resp:
+                    if resp.status != 200:
+                        return f"Error: HTTP {resp.status}"
+
+                    entities = await resp.json()
+                    return self._format_entity_list(entities)
+
+    def _format_entity_state(self, entity: dict[str, Any]) -> str:
+        """Format a single entity's state for display."""
+        entity_id = entity.get("entity_id", "unknown")
+        state = entity.get("state", "unknown")
+        attrs = entity.get("attributes", {})
+        friendly_name = attrs.get("friendly_name", entity_id)
+
+        lines = [f"{friendly_name}: {state}"]
+
+        # Add relevant attributes based on entity type
+        if entity_id.startswith("light."):
+            if brightness := attrs.get("brightness"):
+                pct = round(brightness / 255 * 100)
+                lines.append(f"  Brightness: {pct}%")
+            if color_temp := attrs.get("color_temp"):
+                lines.append(f"  Color temp: {color_temp}")
+        elif entity_id.startswith("climate."):
+            if temp := attrs.get("temperature"):
+                lines.append(f"  Target: {temp}°")
+            if current := attrs.get("current_temperature"):
+                lines.append(f"  Current: {current}°")
+        elif entity_id.startswith("media_player."):
+            if media_title := attrs.get("media_title"):
+                lines.append(f"  Playing: {media_title}")
+            if volume := attrs.get("volume_level"):
+                lines.append(f"  Volume: {round(volume * 100)}%")
+
+        return "\n".join(lines)
+
+    def _format_entity_list(self, entities: list[dict[str, Any]]) -> str:
+        """Format a list of entities grouped by domain."""
+        by_domain: dict[str, list[tuple[str, str, str]]] = {}
+
+        for entity in entities:
+            entity_id = entity.get("entity_id", "")
+            state = entity.get("state", "unknown")
+            friendly_name = entity.get("attributes", {}).get("friendly_name", entity_id)
+
+            domain = entity_id.split(".")[0] if "." in entity_id else "other"
+            if domain not in by_domain:
+                by_domain[domain] = []
+            by_domain[domain].append((entity_id, friendly_name, state))
+
+        # Format output, prioritizing common domains
+        priority_domains = ["light", "switch", "climate", "media_player", "cover", "fan"]
+        lines = ["Home Assistant Entities:"]
+
+        for domain in priority_domains:
+            if domain in by_domain:
+                lines.append(f"\n{domain.replace('_', ' ').title()}s:")
+                for entity_id, name, state in sorted(by_domain[domain]):
+                    lines.append(f"  - {name}: {state} ({entity_id})")
+                del by_domain[domain]
+
+        # Add remaining domains
+        for domain, items in sorted(by_domain.items()):
+            if len(items) <= 10:  # Skip large domains like sensor
+                lines.append(f"\n{domain.replace('_', ' ').title()}:")
+                for entity_id, name, state in sorted(items):
+                    lines.append(f"  - {name}: {state}")
+
+        return "\n".join(lines)
+
+    async def _simple_action(
+        self,
+        action: str,
+        entity_id: str | None,
+        service_data: dict[str, Any],
+    ) -> str:
+        """Execute turn_on, turn_off, or toggle."""
+        if not entity_id:
+            return f"Error: entity_id is required for {action}"
+
+        domain = entity_id.split(".")[0] if "." in entity_id else "homeassistant"
+
+        # Merge entity_id into service_data
+        data = {**service_data, "entity_id": entity_id}
+
+        async with aiohttp.ClientSession() as session:
+            url = f"{self.base_url}/api/services/{domain}/{action}"
+            async with session.post(url, headers=self._get_headers(), json=data) as resp:
+                if resp.status not in (200, 201):
+                    error_text = await resp.text()
+                    return f"Error: HTTP {resp.status} - {error_text}"
+
+                # Get friendly name for response
+                states = await resp.json()
+                if states and isinstance(states, list):
+                    name = states[0].get("attributes", {}).get("friendly_name", entity_id)
+                    new_state = states[0].get("state", "unknown")
+                    return f"{name}: {action.replace('_', ' ')} -> {new_state}"
+
+                return f"OK: {action} {entity_id}"
+
+    async def _call_service(
+        self,
+        domain: str | None,
+        service: str | None,
+        entity_id: str | None,
+        service_data: dict[str, Any],
+    ) -> str:
+        """Call an arbitrary Home Assistant service."""
+        if not service:
+            return "Error: 'service' is required for call_service action"
+
+        # Infer domain from entity_id if not provided
+        if not domain:
+            if entity_id and "." in entity_id:
+                domain = entity_id.split(".")[0]
+            else:
+                return "Error: 'domain' is required when entity_id doesn't specify one"
+
+        # Build service data
+        data = dict(service_data)
+        if entity_id:
+            data["entity_id"] = entity_id
+
+        async with aiohttp.ClientSession() as session:
+            url = f"{self.base_url}/api/services/{domain}/{service}"
+            async with session.post(url, headers=self._get_headers(), json=data) as resp:
+                if resp.status not in (200, 201):
+                    error_text = await resp.text()
+                    return f"Error: HTTP {resp.status} - {error_text}"
+
+                result = await resp.json()
+                if result and isinstance(result, list) and len(result) > 0:
+                    # Return info about affected entities
+                    affected = [e.get("entity_id", "?") for e in result[:5]]
+                    return f"OK: {domain}.{service} -> affected: {', '.join(affected)}"
+
+                return f"OK: {domain}.{service} called successfully"
+
+
+class ListEntitiesByDomainTool(Tool):
+    """List Home Assistant entities filtered by domain.
+
+    Useful for discovering what devices are available in a specific category.
+    """
+
+    def __init__(
+        self,
+        base_url: str | None = None,
+        token: str | None = None,
+    ):
+        self.base_url = (base_url or os.environ.get("HOME_ASSISTANT_URL", "")).rstrip("/")
+        self.token = token or os.environ.get("HOME_ASSISTANT_TOKEN", "")
+
+    def _get_headers(self) -> dict[str, str]:
+        return {
+            "Authorization": f"Bearer {self.token}",
+            "Content-Type": "application/json",
+        }
+
+    @property
+    def name(self) -> str:
+        return "list_ha_entities"
+
+    @property
+    def description(self) -> str:
+        return (
+            "List available Home Assistant entities, optionally filtered by domain. "
+            "Use this to discover what devices can be controlled "
+            "(e.g., 'light' for all lights, 'switch' for all switches)."
+        )
+
+    @property
+    def parameters(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "domain": {
+                    "type": "string",
+                    "description": (
+                        "Filter by domain (e.g., 'light', 'switch', 'climate', 'media_player'). "
+                        "If not specified, returns a summary of all domains."
+                    )
+                }
+            },
+            "required": []
+        }
+
+    async def execute(self, **kwargs: Any) -> str:
+        domain_filter = kwargs.get("domain")
+
+        if not self.base_url or not self.token:
+            return "Error: HOME_ASSISTANT_URL and HOME_ASSISTANT_TOKEN must be configured."
+
+        try:
+            async with aiohttp.ClientSession() as session:
+                url = f"{self.base_url}/api/states"
+                async with session.get(url, headers=self._get_headers()) as resp:
+                    if resp.status != 200:
+                        return f"Error: HTTP {resp.status}"
+
+                    entities = await resp.json()
+
+                    if domain_filter:
+                        # Filter to specific domain
+                        filtered = [
+                            e for e in entities
+                            if e.get("entity_id", "").startswith(f"{domain_filter}.")
+                        ]
+                        if not filtered:
+                            return f"No entities found in domain '{domain_filter}'"
+
+                        lines = [f"{domain_filter.title()} entities:"]
+                        for entity in sorted(filtered, key=lambda e: e.get("entity_id", "")):
+                            entity_id = entity.get("entity_id", "")
+                            state = entity.get("state", "unknown")
+                            name = entity.get("attributes", {}).get("friendly_name", entity_id)
+                            lines.append(f"  - {name}: {state} ({entity_id})")
+                        return "\n".join(lines)
+                    else:
+                        # Return domain summary
+                        domains: dict[str, int] = {}
+                        for entity in entities:
+                            entity_id = entity.get("entity_id", "")
+                            domain = entity_id.split(".")[0] if "." in entity_id else "other"
+                            domains[domain] = domains.get(domain, 0) + 1
+
+                        lines = ["Available domains:"]
+                        for domain, count in sorted(domains.items()):
+                            lines.append(f"  - {domain}: {count} entities")
+                        return "\n".join(lines)
+
+        except aiohttp.ClientError as e:
+            return f"Error connecting to Home Assistant: {e}"
+        except Exception as e:
+            return f"Error: {e}"

--- a/nanobot/tools/test_home_assistant.py
+++ b/nanobot/tools/test_home_assistant.py
@@ -1,0 +1,237 @@
+"""Tests for Home Assistant tool.
+
+Run with: pytest nanobot/tools/test_home_assistant.py -v
+
+These tests use mocked responses - no real Home Assistant required.
+"""
+
+import pytest
+from unittest.mock import AsyncMock, patch, MagicMock
+from home_assistant import HomeAssistantTool, ListEntitiesByDomainTool
+
+
+@pytest.fixture
+def tool():
+    """Create a tool instance with test config."""
+    return HomeAssistantTool(
+        base_url="http://homeassistant:8123",
+        token="test_token_123"
+    )
+
+
+@pytest.fixture
+def list_tool():
+    """Create a list entities tool instance."""
+    return ListEntitiesByDomainTool(
+        base_url="http://homeassistant:8123",
+        token="test_token_123"
+    )
+
+
+class TestHomeAssistantTool:
+    """Tests for the main HomeAssistantTool."""
+
+    def test_tool_properties(self, tool):
+        """Verify tool has required properties."""
+        assert tool.name == "home_assistant"
+        assert "Control smart home" in tool.description
+        assert "action" in tool.parameters["properties"]
+        assert tool.parameters["required"] == ["action"]
+
+    def test_to_schema(self, tool):
+        """Verify OpenAI function schema format."""
+        schema = tool.to_schema()
+        assert schema["type"] == "function"
+        assert schema["function"]["name"] == "home_assistant"
+        assert "parameters" in schema["function"]
+
+    @pytest.mark.asyncio
+    async def test_missing_config(self):
+        """Error when URL/token not configured."""
+        tool = HomeAssistantTool(base_url="", token="")
+        result = await tool.execute(action="get_state", entity_id="light.test")
+        assert "must be configured" in result
+
+    @pytest.mark.asyncio
+    async def test_get_state_single_entity(self, tool):
+        """Test getting state of a single entity."""
+        mock_response = {
+            "entity_id": "light.living_room",
+            "state": "on",
+            "attributes": {
+                "friendly_name": "Living Room Light",
+                "brightness": 128
+            }
+        }
+
+        with patch("aiohttp.ClientSession") as mock_session:
+            mock_resp = AsyncMock()
+            mock_resp.status = 200
+            mock_resp.json = AsyncMock(return_value=mock_response)
+
+            mock_session.return_value.__aenter__.return_value.get.return_value.__aenter__.return_value = mock_resp
+
+            result = await tool.execute(action="get_state", entity_id="light.living_room")
+
+            assert "Living Room Light" in result
+            assert "on" in result
+            assert "Brightness: 50%" in result  # 128/255 ≈ 50%
+
+    @pytest.mark.asyncio
+    async def test_get_state_not_found(self, tool):
+        """Test handling of missing entity."""
+        with patch("aiohttp.ClientSession") as mock_session:
+            mock_resp = AsyncMock()
+            mock_resp.status = 404
+
+            mock_session.return_value.__aenter__.return_value.get.return_value.__aenter__.return_value = mock_resp
+
+            result = await tool.execute(action="get_state", entity_id="light.nonexistent")
+
+            assert "not found" in result
+
+    @pytest.mark.asyncio
+    async def test_turn_on(self, tool):
+        """Test turning on a device."""
+        mock_response = [{
+            "entity_id": "light.kitchen",
+            "state": "on",
+            "attributes": {"friendly_name": "Kitchen Light"}
+        }]
+
+        with patch("aiohttp.ClientSession") as mock_session:
+            mock_resp = AsyncMock()
+            mock_resp.status = 200
+            mock_resp.json = AsyncMock(return_value=mock_response)
+
+            mock_session.return_value.__aenter__.return_value.post.return_value.__aenter__.return_value = mock_resp
+
+            result = await tool.execute(action="turn_on", entity_id="light.kitchen")
+
+            assert "Kitchen Light" in result
+            assert "turn on" in result
+            assert "on" in result
+
+    @pytest.mark.asyncio
+    async def test_turn_off(self, tool):
+        """Test turning off a device."""
+        mock_response = [{
+            "entity_id": "switch.coffee_maker",
+            "state": "off",
+            "attributes": {"friendly_name": "Coffee Maker"}
+        }]
+
+        with patch("aiohttp.ClientSession") as mock_session:
+            mock_resp = AsyncMock()
+            mock_resp.status = 200
+            mock_resp.json = AsyncMock(return_value=mock_response)
+
+            mock_session.return_value.__aenter__.return_value.post.return_value.__aenter__.return_value = mock_resp
+
+            result = await tool.execute(action="turn_off", entity_id="switch.coffee_maker")
+
+            assert "Coffee Maker" in result
+
+    @pytest.mark.asyncio
+    async def test_turn_on_missing_entity_id(self, tool):
+        """Error when entity_id missing for turn_on."""
+        result = await tool.execute(action="turn_on")
+        assert "entity_id is required" in result
+
+    @pytest.mark.asyncio
+    async def test_call_service_with_data(self, tool):
+        """Test calling a service with extra data."""
+        mock_response = [{
+            "entity_id": "light.bedroom",
+            "state": "on"
+        }]
+
+        with patch("aiohttp.ClientSession") as mock_session:
+            mock_resp = AsyncMock()
+            mock_resp.status = 200
+            mock_resp.json = AsyncMock(return_value=mock_response)
+            mock_post = mock_session.return_value.__aenter__.return_value.post
+            mock_post.return_value.__aenter__.return_value = mock_resp
+
+            result = await tool.execute(
+                action="call_service",
+                entity_id="light.bedroom",
+                service="turn_on",
+                service_data={"brightness": 200}
+            )
+
+            assert "OK" in result
+
+    @pytest.mark.asyncio
+    async def test_call_service_missing_service(self, tool):
+        """Error when service name missing."""
+        result = await tool.execute(
+            action="call_service",
+            entity_id="light.test"
+        )
+        assert "'service' is required" in result
+
+    @pytest.mark.asyncio
+    async def test_unknown_action(self, tool):
+        """Error on unknown action."""
+        result = await tool.execute(action="explode", entity_id="light.test")
+        assert "Unknown action" in result
+
+
+class TestListEntitiesByDomainTool:
+    """Tests for ListEntitiesByDomainTool."""
+
+    def test_tool_properties(self, list_tool):
+        """Verify tool properties."""
+        assert list_tool.name == "list_ha_entities"
+        assert "List available" in list_tool.description
+        assert list_tool.parameters["required"] == []
+
+    @pytest.mark.asyncio
+    async def test_list_by_domain(self, list_tool):
+        """Test listing entities filtered by domain."""
+        mock_response = [
+            {"entity_id": "light.living_room", "state": "on", "attributes": {"friendly_name": "Living Room"}},
+            {"entity_id": "light.kitchen", "state": "off", "attributes": {"friendly_name": "Kitchen"}},
+            {"entity_id": "switch.fan", "state": "off", "attributes": {"friendly_name": "Fan"}},
+        ]
+
+        with patch("aiohttp.ClientSession") as mock_session:
+            mock_resp = AsyncMock()
+            mock_resp.status = 200
+            mock_resp.json = AsyncMock(return_value=mock_response)
+
+            mock_session.return_value.__aenter__.return_value.get.return_value.__aenter__.return_value = mock_resp
+
+            result = await list_tool.execute(domain="light")
+
+            assert "Living Room" in result
+            assert "Kitchen" in result
+            assert "Fan" not in result  # switch, not light
+
+    @pytest.mark.asyncio
+    async def test_list_domain_summary(self, list_tool):
+        """Test getting domain summary when no filter specified."""
+        mock_response = [
+            {"entity_id": "light.a", "state": "on", "attributes": {}},
+            {"entity_id": "light.b", "state": "off", "attributes": {}},
+            {"entity_id": "switch.c", "state": "on", "attributes": {}},
+            {"entity_id": "sensor.d", "state": "25", "attributes": {}},
+        ]
+
+        with patch("aiohttp.ClientSession") as mock_session:
+            mock_resp = AsyncMock()
+            mock_resp.status = 200
+            mock_resp.json = AsyncMock(return_value=mock_response)
+
+            mock_session.return_value.__aenter__.return_value.get.return_value.__aenter__.return_value = mock_resp
+
+            result = await list_tool.execute()
+
+            assert "light: 2 entities" in result
+            assert "switch: 1 entities" in result
+            assert "sensor: 1 entities" in result
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary
- Adds `HomeAssistantTool` for controlling smart home devices via HA REST API
- Adds `ListEntitiesByDomainTool` for discovering available devices
- Includes comprehensive test suite with mocked responses

## Features
| Action | Description |
|--------|-------------|
| `turn_on` | Turn on a device |
| `turn_off` | Turn off a device |
| `toggle` | Toggle device state |
| `get_state` | Get current state with formatted attributes |
| `call_service` | Call any HA service with custom data |

## Test plan
- [x] Python syntax validation passes
- [x] Tool follows Nanobot pattern (matches memory.py)
- [ ] Unit tests pass with pytest
- [ ] Integration test with real Home Assistant (post-hardware)

Closes #4