### PR TITLE
Add auto-initialization of Butler schema in PostgreSQL

### DIFF
--- a/docs/10-photos-files.md
+++ b/docs/10-photos-files.md
@@ -72,11 +72,21 @@ docker compose ps
 
 This stack includes PostgreSQL with vector extensions (for Immich's ML features). The same database will be used for:
 
-| Database | Purpose |
-|----------|---------|
+| Database/Schema | Purpose |
+|-----------------|---------|
 | `immich` | Immich photo metadata |
 | `nextcloud` | Nextcloud file metadata |
-| `butler` schema | Butler AI memory (future - issue #12) |
+| `butler.*` | Butler AI memory (auto-initialized) |
+
+**Butler schema tables:**
+| Table | Purpose |
+|-------|---------|
+| `butler.users` | User profiles and soul/personality config |
+| `butler.user_facts` | Things Butler learns about users |
+| `butler.conversation_history` | Conversation context for continuity |
+| `butler.scheduled_tasks` | Reminders and automations |
+
+The Butler schema is automatically initialized when this script runs. It's idempotent (safe to run multiple times).
 
 **Connection details:**
 - Host: `localhost:5432` (from Mac) or `immich-postgres:5432` (from containers)
@@ -191,6 +201,22 @@ docker exec immich-postgres psql -U postgres -c "SELECT 1"
 
 # Check logs
 docker logs immich-postgres
+```
+
+### Butler schema issues
+
+```bash
+# Verify Butler schema exists
+docker exec immich-postgres psql -U postgres -d immich -c "\dn butler"
+
+# List Butler tables
+docker exec immich-postgres psql -U postgres -d immich -c "\dt butler.*"
+
+# Re-run initialization (safe, idempotent)
+./scripts/init-butler-schema.sh
+
+# Check default user exists
+docker exec immich-postgres psql -U postgres -d immich -c "SELECT * FROM butler.users;"
 ```
 
 ## Backup Considerations

--- a/scripts/10-photos-files.sh
+++ b/scripts/10-photos-files.sh
@@ -60,6 +60,11 @@ else
     echo -e "  ${YELLOW}⚠${NC} PostgreSQL may still be starting..."
 fi
 
+# Initialize Butler schema for Nanobot memory
+echo ""
+echo -e "${BLUE}==>${NC} Setting up Butler schema for AI memory..."
+"$SCRIPT_DIR/init-butler-schema.sh"
+
 echo ""
 echo -e "${GREEN}✓${NC} Photos & Files stack deployed"
 echo ""
@@ -80,7 +85,7 @@ echo -e "${YELLOW}PostgreSQL shared database:${NC}"
 echo "  - Host: localhost:5432 or immich-postgres:5432 (from containers)"
 echo "  - Immich DB: immich"
 echo "  - Nextcloud DB: nextcloud"
-echo "  - Butler schema will be added later (issue #12)"
+echo "  - Butler schema: butler.* (users, user_facts, conversation_history, scheduled_tasks)"
 echo ""
 echo -e "${YELLOW}Next:${NC} Deploy smart home stack with:"
 echo "  ./scripts/11-smart-home.sh"

--- a/scripts/init-butler-schema.sh
+++ b/scripts/init-butler-schema.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+# Initialize Butler schema in PostgreSQL
+# This script is idempotent - safe to run multiple times
+set -e
+
+GREEN='\033[0;32m'
+BLUE='\033[0;34m'
+YELLOW='\033[1;33m'
+RED='\033[0;31m'
+NC='\033[0m'
+
+# Configuration
+POSTGRES_CONTAINER="${POSTGRES_CONTAINER:-immich-postgres}"
+POSTGRES_DB="${POSTGRES_DB:-immich}"
+POSTGRES_USER="${POSTGRES_USER:-postgres}"
+MAX_RETRIES="${MAX_RETRIES:-30}"
+RETRY_INTERVAL="${RETRY_INTERVAL:-2}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MIGRATION_FILE="${SCRIPT_DIR}/../nanobot/migrations/001_butler_schema.sql"
+
+echo -e "${BLUE}==>${NC} Initializing Butler schema..."
+
+# Check migration file exists
+if [[ ! -f "$MIGRATION_FILE" ]]; then
+    echo -e "${RED}✗${NC} Migration file not found: $MIGRATION_FILE"
+    exit 1
+fi
+
+# Wait for PostgreSQL to be ready
+echo -e "${BLUE}==>${NC} Waiting for PostgreSQL to be ready..."
+retries=0
+until docker exec "$POSTGRES_CONTAINER" pg_isready -U "$POSTGRES_USER" &>/dev/null; do
+    retries=$((retries + 1))
+    if [[ $retries -ge $MAX_RETRIES ]]; then
+        echo -e "${RED}✗${NC} PostgreSQL not ready after $MAX_RETRIES attempts"
+        exit 1
+    fi
+    echo -e "  ${YELLOW}⏳${NC} Waiting for PostgreSQL... (attempt $retries/$MAX_RETRIES)"
+    sleep "$RETRY_INTERVAL"
+done
+echo -e "  ${GREEN}✓${NC} PostgreSQL is ready"
+
+# Copy migration file to container and execute
+echo -e "${BLUE}==>${NC} Running Butler schema migration..."
+docker cp "$MIGRATION_FILE" "$POSTGRES_CONTAINER:/tmp/butler_schema.sql"
+docker exec "$POSTGRES_CONTAINER" psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" -f /tmp/butler_schema.sql -q
+
+# Verify schema was created
+echo -e "${BLUE}==>${NC} Verifying schema..."
+SCHEMA_EXISTS=$(docker exec "$POSTGRES_CONTAINER" psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" -tAc \
+    "SELECT EXISTS(SELECT 1 FROM information_schema.schemata WHERE schema_name = 'butler');")
+
+if [[ "$SCHEMA_EXISTS" == "t" ]]; then
+    echo -e "  ${GREEN}✓${NC} Butler schema created successfully"
+else
+    echo -e "${RED}✗${NC} Failed to verify Butler schema"
+    exit 1
+fi
+
+# Count tables for confirmation
+TABLE_COUNT=$(docker exec "$POSTGRES_CONTAINER" psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" -tAc \
+    "SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = 'butler';")
+echo -e "  ${GREEN}✓${NC} Butler schema contains $TABLE_COUNT tables"
+
+echo -e "${GREEN}✓${NC} Butler schema initialization complete"


### PR DESCRIPTION
## Summary
- Creates `scripts/init-butler-schema.sh` with PostgreSQL retry logic
- Calls schema initialization from `10-photos-files.sh` after containers start
- Verifies schema creation by checking table count
- Updates documentation with Butler schema tables and troubleshooting commands

Closes #34

## Test plan
- [ ] Run `./scripts/10-photos-files.sh` on a fresh deployment
- [ ] Verify Butler schema exists: `docker exec immich-postgres psql -U postgres -d immich -c "\dn butler"`
- [ ] Verify tables created: `docker exec immich-postgres psql -U postgres -d immich -c "\dt butler.*"`
- [ ] Run `./scripts/init-butler-schema.sh` again to verify idempotency
- [ ] Test with PostgreSQL not ready (should retry and succeed)