### PR TITLE
Build Weather Tool

### DIFF
--- a/nanobot/.env.example
+++ b/nanobot/.env.example
@@ -25,6 +25,13 @@ DB_PASSWORD=postgres
 HA_TOKEN=eyJ...
 
 # ===================
+# Weather (OpenWeatherMap, optional)
+# ===================
+
+# API key from https://openweathermap.org/api (free tier: 1000 calls/day)
+OPENWEATHERMAP_API_KEY=
+
+# ===================
 # Telegram (optional)
 # ===================
 

--- a/nanobot/api/config.py
+++ b/nanobot/api/config.py
@@ -31,6 +31,9 @@ class Settings(BaseSettings):
     home_assistant_url: str = ""
     home_assistant_token: str = ""
 
+    # Weather (OpenWeatherMap)
+    openweathermap_api_key: str = ""
+
     # Service-to-service auth (LiveKit Agents -> butler-api)
     internal_api_key: str = ""
 

--- a/nanobot/api/deps.py
+++ b/nanobot/api/deps.py
@@ -19,6 +19,7 @@ from tools import (
     RememberFactTool,
     GetUserTool,
     Tool,
+    WeatherTool,
 )
 
 from .auth import decode_user_jwt
@@ -49,6 +50,12 @@ async def init_resources() -> None:
         _tools["list_ha_entities"] = ListEntitiesByDomainTool(
             base_url=settings.home_assistant_url,
             token=settings.home_assistant_token,
+        )
+
+    # Only register weather tool if configured
+    if settings.openweathermap_api_key:
+        _tools["weather"] = WeatherTool(
+            api_key=settings.openweathermap_api_key,
         )
 
 

--- a/nanobot/tools/__init__.py
+++ b/nanobot/tools/__init__.py
@@ -28,6 +28,7 @@ from .memory import (
     VALID_SOUL_KEYS,
 )
 from .home_assistant import HomeAssistantTool, ListEntitiesByDomainTool
+from .weather import WeatherTool
 
 __all__ = [
     # Base
@@ -45,4 +46,6 @@ __all__ = [
     # Home Assistant
     "HomeAssistantTool",
     "ListEntitiesByDomainTool",
+    # Weather
+    "WeatherTool",
 ]

--- a/nanobot/tools/test_weather.py
+++ b/nanobot/tools/test_weather.py
@@ -1,0 +1,263 @@
+"""Tests for Weather tool.
+
+Run with: pytest nanobot/tools/test_weather.py -v
+
+These tests use mocked responses - no real API key required.
+"""
+
+import pytest
+from unittest.mock import AsyncMock, patch
+
+from .weather import WeatherTool
+
+
+# Sample API responses for mocking
+SAMPLE_CURRENT = {
+    "name": "London",
+    "sys": {"country": "GB", "sunrise": 1707204720, "sunset": 1707238020},
+    "main": {"temp": 8.5, "feels_like": 6.2, "humidity": 82},
+    "weather": [{"description": "light rain", "main": "Rain"}],
+    "wind": {"speed": 4.1},
+    "timezone": 0,
+}
+
+SAMPLE_FORECAST = {
+    "city": {"name": "London", "country": "GB"},
+    "list": [
+        {
+            "dt_txt": "2025-02-10 06:00:00",
+            "main": {"temp": 7.0, "temp_min": 6.0, "temp_max": 8.0},
+            "weather": [{"description": "overcast clouds"}],
+            "pop": 0.1,
+        },
+        {
+            "dt_txt": "2025-02-10 09:00:00",
+            "main": {"temp": 8.0, "temp_min": 7.0, "temp_max": 9.0},
+            "weather": [{"description": "light rain"}],
+            "pop": 0.8,
+        },
+        {
+            "dt_txt": "2025-02-10 12:00:00",
+            "main": {"temp": 9.5, "temp_min": 8.5, "temp_max": 10.0},
+            "weather": [{"description": "light rain"}],
+            "pop": 0.7,
+        },
+        {
+            "dt_txt": "2025-02-11 06:00:00",
+            "main": {"temp": 5.0, "temp_min": 4.0, "temp_max": 6.0},
+            "weather": [{"description": "clear sky"}],
+            "pop": 0.0,
+        },
+        {
+            "dt_txt": "2025-02-11 12:00:00",
+            "main": {"temp": 7.0, "temp_min": 5.0, "temp_max": 8.0},
+            "weather": [{"description": "clear sky"}],
+            "pop": 0.05,
+        },
+        {
+            "dt_txt": "2025-02-12 09:00:00",
+            "main": {"temp": 10.0, "temp_min": 9.0, "temp_max": 12.0},
+            "weather": [{"description": "scattered clouds"}],
+            "pop": 0.15,
+        },
+    ],
+}
+
+
+@pytest.fixture
+def tool():
+    """Create a tool instance with test config."""
+    return WeatherTool(api_key="test_key_123")
+
+
+class TestWeatherTool:
+    """Tests for the WeatherTool."""
+
+    def test_tool_properties(self, tool):
+        """Verify tool has required properties."""
+        assert tool.name == "weather"
+        assert "current weather" in tool.description or "forecast" in tool.description
+        assert "action" in tool.parameters["properties"]
+        assert "location" in tool.parameters["properties"]
+        assert tool.parameters["required"] == ["action", "location"]
+
+    def test_to_schema(self, tool):
+        """Verify OpenAI function schema format."""
+        schema = tool.to_schema()
+        assert schema["type"] == "function"
+        assert schema["function"]["name"] == "weather"
+        assert "parameters" in schema["function"]
+
+    @pytest.mark.asyncio
+    async def test_missing_api_key(self):
+        """Error when API key not configured."""
+        tool = WeatherTool(api_key="")
+        result = await tool.execute(action="current", location="London")
+        assert "must be configured" in result
+
+    @pytest.mark.asyncio
+    async def test_current_weather(self, tool):
+        """Test fetching current weather."""
+        with patch("tools.weather.aiohttp.ClientSession") as mock_session:
+            mock_resp = AsyncMock()
+            mock_resp.status = 200
+            mock_resp.json = AsyncMock(return_value=SAMPLE_CURRENT)
+
+            mock_session.return_value.get.return_value.__aenter__.return_value = mock_resp
+
+            result = await tool.execute(action="current", location="London,GB")
+
+            assert "London, GB" in result
+            assert "8°C" in result
+            assert "Light rain" in result
+            assert "Humidity: 82%" in result
+            assert "4.1 m/s" in result
+
+    @pytest.mark.asyncio
+    async def test_current_weather_not_found(self, tool):
+        """Test handling of unknown location."""
+        with patch("tools.weather.aiohttp.ClientSession") as mock_session:
+            mock_resp = AsyncMock()
+            mock_resp.status = 404
+
+            mock_session.return_value.get.return_value.__aenter__.return_value = mock_resp
+
+            result = await tool.execute(action="current", location="Nonexistentville")
+
+            assert "not found" in result
+
+    @pytest.mark.asyncio
+    async def test_current_weather_invalid_key(self, tool):
+        """Test handling of invalid API key."""
+        with patch("tools.weather.aiohttp.ClientSession") as mock_session:
+            mock_resp = AsyncMock()
+            mock_resp.status = 401
+
+            mock_session.return_value.get.return_value.__aenter__.return_value = mock_resp
+
+            result = await tool.execute(action="current", location="London")
+
+            assert "Invalid API key" in result
+
+    @pytest.mark.asyncio
+    async def test_forecast(self, tool):
+        """Test fetching multi-day forecast."""
+        with patch("tools.weather.aiohttp.ClientSession") as mock_session:
+            mock_resp = AsyncMock()
+            mock_resp.status = 200
+            mock_resp.json = AsyncMock(return_value=SAMPLE_FORECAST)
+
+            mock_session.return_value.get.return_value.__aenter__.return_value = mock_resp
+
+            result = await tool.execute(action="forecast", location="London,GB", days=3)
+
+            assert "London, GB" in result
+            assert "forecast" in result.lower()
+            # Should have entries for Feb 10, 11, 12
+            assert "Mon 10 Feb" in result
+            assert "Tue 11 Feb" in result
+            assert "Wed 12 Feb" in result
+
+    @pytest.mark.asyncio
+    async def test_forecast_day_limit(self, tool):
+        """Test that days parameter limits output."""
+        with patch("tools.weather.aiohttp.ClientSession") as mock_session:
+            mock_resp = AsyncMock()
+            mock_resp.status = 200
+            mock_resp.json = AsyncMock(return_value=SAMPLE_FORECAST)
+
+            mock_session.return_value.get.return_value.__aenter__.return_value = mock_resp
+
+            result = await tool.execute(action="forecast", location="London", days=1)
+
+            assert "Mon 10 Feb" in result
+            assert "Tue 11 Feb" not in result  # Should be excluded
+
+    @pytest.mark.asyncio
+    async def test_forecast_aggregation(self, tool):
+        """Test that forecast aggregates 3-hour blocks correctly."""
+        with patch("tools.weather.aiohttp.ClientSession") as mock_session:
+            mock_resp = AsyncMock()
+            mock_resp.status = 200
+            mock_resp.json = AsyncMock(return_value=SAMPLE_FORECAST)
+
+            mock_session.return_value.get.return_value.__aenter__.return_value = mock_resp
+
+            result = await tool.execute(action="forecast", location="London", days=3)
+
+            # Feb 10: min=6, max=10 -> "6-10°C"
+            assert "6-10°C" in result
+            # Feb 10 has light rain twice, overcast once -> "Light rain" wins
+            assert "Light rain" in result
+            # Feb 10 has max pop=0.8 -> should show precip
+            assert "80% precip" in result
+
+    @pytest.mark.asyncio
+    async def test_forecast_not_found(self, tool):
+        """Test forecast with unknown location."""
+        with patch("tools.weather.aiohttp.ClientSession") as mock_session:
+            mock_resp = AsyncMock()
+            mock_resp.status = 404
+
+            mock_session.return_value.get.return_value.__aenter__.return_value = mock_resp
+
+            result = await tool.execute(action="forecast", location="Nonexistentville")
+
+            assert "not found" in result
+
+    @pytest.mark.asyncio
+    async def test_units_imperial(self, tool):
+        """Test imperial units in output."""
+        imperial_data = dict(SAMPLE_CURRENT)
+        imperial_data["main"] = {"temp": 47.3, "feels_like": 43.2, "humidity": 82}
+        imperial_data["wind"] = {"speed": 9.2}
+
+        with patch("tools.weather.aiohttp.ClientSession") as mock_session:
+            mock_resp = AsyncMock()
+            mock_resp.status = 200
+            mock_resp.json = AsyncMock(return_value=imperial_data)
+
+            mock_session.return_value.get.return_value.__aenter__.return_value = mock_resp
+
+            result = await tool.execute(
+                action="current", location="London", units="imperial"
+            )
+
+            assert "°F" in result
+            assert "mph" in result
+
+    @pytest.mark.asyncio
+    async def test_unknown_action(self, tool):
+        """Error on unknown action."""
+        result = await tool.execute(action="explode", location="London")
+        assert "Unknown action" in result
+
+    @pytest.mark.asyncio
+    async def test_connection_error(self, tool):
+        """Test handling of connection errors."""
+        import aiohttp
+
+        with patch("tools.weather.aiohttp.ClientSession") as mock_session:
+            mock_session.return_value.get.return_value.__aenter__.side_effect = (
+                aiohttp.ClientError("Connection refused")
+            )
+
+            result = await tool.execute(action="current", location="London")
+
+            assert "Error" in result
+
+    @pytest.mark.asyncio
+    async def test_timeout_error(self, tool):
+        """Test handling of timeout errors."""
+        with patch("tools.weather.aiohttp.ClientSession") as mock_session:
+            mock_session.return_value.get.return_value.__aenter__.side_effect = (
+                TimeoutError()
+            )
+
+            result = await tool.execute(action="current", location="London")
+
+            assert "timed out" in result
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/nanobot/tools/weather.py
+++ b/nanobot/tools/weather.py
@@ -1,0 +1,293 @@
+"""Weather integration tool for Butler.
+
+This tool allows the agent to check current weather conditions and
+multi-day forecasts via the OpenWeatherMap API.
+
+Usage:
+    The tool is automatically registered with Nanobot when the container starts.
+    It requires OPENWEATHERMAP_API_KEY to be set in the application settings.
+
+Example:
+    tool = WeatherTool()
+    result = await tool.execute(action="current", location="London,GB")
+
+    # When shutting down
+    await tool.close()
+
+API Reference:
+    https://openweathermap.org/current
+    https://openweathermap.org/forecast5
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from datetime import datetime, timezone, timedelta
+from typing import Any
+
+import aiohttp
+
+from .base import Tool
+
+# Default timeout for HTTP requests (seconds)
+DEFAULT_TIMEOUT = 10
+
+# OpenWeatherMap API base URL
+OWM_BASE_URL = "https://api.openweathermap.org/data/2.5"
+
+
+class WeatherTool(Tool):
+    """Fetch current weather and forecasts from OpenWeatherMap.
+
+    Supports two actions:
+    - "current": Get current conditions for a location
+    - "forecast": Get a multi-day forecast (up to 5 days)
+
+    The tool reuses HTTP sessions for better performance and
+    includes configurable timeouts for reliability.
+    """
+
+    def __init__(
+        self,
+        api_key: str | None = None,
+        timeout: int = DEFAULT_TIMEOUT,
+    ):
+        """Initialize the Weather tool.
+
+        Args:
+            api_key: OpenWeatherMap API key (passed from settings)
+            timeout: HTTP request timeout in seconds (default: 10)
+        """
+        self.api_key = api_key or ""
+        self.timeout = aiohttp.ClientTimeout(total=timeout)
+        self._session: aiohttp.ClientSession | None = None
+
+    async def _get_session(self) -> aiohttp.ClientSession:
+        """Get or create the HTTP session."""
+        if self._session is None or self._session.closed:
+            self._session = aiohttp.ClientSession(timeout=self.timeout)
+        return self._session
+
+    async def close(self) -> None:
+        """Close the HTTP session.
+
+        Should be called when shutting down to cleanly release connections.
+        """
+        if self._session and not self._session.closed:
+            await self._session.close()
+            self._session = None
+
+    @property
+    def name(self) -> str:
+        return "weather"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Get current weather conditions or a multi-day forecast for any location. "
+            "Use 'current' for right now, 'forecast' for upcoming days (up to 5). "
+            "Locations can be city names like 'London' or 'London,GB' for precision."
+        )
+
+    @property
+    def parameters(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "action": {
+                    "type": "string",
+                    "enum": ["current", "forecast"],
+                    "description": (
+                        "Action to perform: "
+                        "'current' for current conditions, "
+                        "'forecast' for multi-day forecast (up to 5 days)"
+                    ),
+                },
+                "location": {
+                    "type": "string",
+                    "description": (
+                        "City name, optionally with country code "
+                        "(e.g., 'London', 'London,GB', 'Tokyo,JP')"
+                    ),
+                },
+                "days": {
+                    "type": "integer",
+                    "description": (
+                        "Number of forecast days (1-5, default: 3). "
+                        "Only used with 'forecast' action."
+                    ),
+                    "minimum": 1,
+                    "maximum": 5,
+                },
+                "units": {
+                    "type": "string",
+                    "enum": ["metric", "imperial"],
+                    "description": (
+                        "Temperature units: 'metric' for Celsius (default), "
+                        "'imperial' for Fahrenheit"
+                    ),
+                },
+            },
+            "required": ["action", "location"],
+        }
+
+    async def execute(self, **kwargs: Any) -> str:
+        action = kwargs["action"]
+        location = kwargs["location"]
+        days = kwargs.get("days", 3)
+        units = kwargs.get("units", "metric")
+
+        if not self.api_key:
+            return "Error: OPENWEATHERMAP_API_KEY must be configured."
+
+        try:
+            if action == "current":
+                return await self._get_current(location, units)
+            elif action == "forecast":
+                return await self._get_forecast(location, units, days)
+            else:
+                return f"Error: Unknown action '{action}'"
+        except aiohttp.ClientError as e:
+            return f"Error connecting to weather service: {e}"
+        except TimeoutError:
+            return "Error: Weather service request timed out"
+        except Exception as e:
+            return f"Error: {e}"
+
+    async def _get_current(self, location: str, units: str) -> str:
+        """Fetch current weather conditions."""
+        session = await self._get_session()
+        params = {"q": location, "appid": self.api_key, "units": units}
+
+        async with session.get(f"{OWM_BASE_URL}/weather", params=params) as resp:
+            if resp.status == 404:
+                return (
+                    f"Location '{location}' not found. "
+                    "Try adding a country code (e.g., 'London,GB')."
+                )
+            if resp.status == 401:
+                return "Error: Invalid API key."
+            if resp.status != 200:
+                return f"Error: HTTP {resp.status}"
+
+            data = await resp.json()
+            return self._format_current(data, units)
+
+    async def _get_forecast(self, location: str, units: str, days: int) -> str:
+        """Fetch and aggregate multi-day forecast."""
+        session = await self._get_session()
+        params = {"q": location, "appid": self.api_key, "units": units}
+
+        async with session.get(f"{OWM_BASE_URL}/forecast", params=params) as resp:
+            if resp.status == 404:
+                return (
+                    f"Location '{location}' not found. "
+                    "Try adding a country code (e.g., 'London,GB')."
+                )
+            if resp.status == 401:
+                return "Error: Invalid API key."
+            if resp.status != 200:
+                return f"Error: HTTP {resp.status}"
+
+            data = await resp.json()
+            return self._aggregate_forecast(data, units, days)
+
+    def _format_current(self, data: dict, units: str) -> str:
+        """Format current weather API response into readable text."""
+        city = data.get("name", "Unknown")
+        country = data.get("sys", {}).get("country", "")
+        location_str = f"{city}, {country}" if country else city
+
+        main = data.get("main", {})
+        temp = main.get("temp", 0)
+        feels_like = main.get("feels_like", 0)
+        humidity = main.get("humidity", 0)
+
+        weather = data.get("weather", [{}])[0]
+        condition = weather.get("description", "unknown").capitalize()
+
+        wind_speed = data.get("wind", {}).get("speed", 0)
+
+        t_unit = self._temp_unit(units)
+        s_unit = self._speed_unit(units)
+
+        lines = [
+            f"{location_str}: {temp:.0f}{t_unit} (feels like {feels_like:.0f}{t_unit})",
+            condition,
+            f"Humidity: {humidity}% | Wind: {wind_speed} {s_unit}",
+        ]
+
+        # Add sunrise/sunset if available
+        sys_data = data.get("sys", {})
+        tz_offset = data.get("timezone", 0)
+        sunrise_ts = sys_data.get("sunrise")
+        sunset_ts = sys_data.get("sunset")
+        if sunrise_ts and sunset_ts:
+            tz = timezone(timedelta(seconds=tz_offset))
+            sunrise = datetime.fromtimestamp(sunrise_ts, tz=tz).strftime("%H:%M")
+            sunset = datetime.fromtimestamp(sunset_ts, tz=tz).strftime("%H:%M")
+            lines.append(f"Sunrise: {sunrise} | Sunset: {sunset}")
+
+        return "\n".join(lines)
+
+    def _aggregate_forecast(self, data: dict, units: str, days: int) -> str:
+        """Aggregate 3-hour forecast blocks into daily summaries."""
+        city_info = data.get("city", {})
+        city = city_info.get("name", "Unknown")
+        country = city_info.get("country", "")
+        location_str = f"{city}, {country}" if country else city
+
+        # Group forecast blocks by date
+        daily: dict[str, list[dict]] = {}
+        for block in data.get("list", []):
+            dt_txt = block.get("dt_txt", "")
+            date_str = dt_txt.split(" ")[0] if dt_txt else ""
+            if date_str:
+                daily.setdefault(date_str, []).append(block)
+
+        t_unit = self._temp_unit(units)
+
+        # Build daily summaries, limited to requested days
+        day_lines = []
+        for date_str in sorted(daily.keys())[:days]:
+            blocks = daily[date_str]
+
+            # Temperature range
+            temps_min = [b["main"]["temp_min"] for b in blocks if "main" in b]
+            temps_max = [b["main"]["temp_max"] for b in blocks if "main" in b]
+            low = min(temps_min) if temps_min else 0
+            high = max(temps_max) if temps_max else 0
+
+            # Most frequent weather condition
+            conditions = [
+                b["weather"][0]["description"]
+                for b in blocks
+                if b.get("weather")
+            ]
+            condition = Counter(conditions).most_common(1)[0][0].capitalize() if conditions else "Unknown"
+
+            # Max precipitation probability
+            max_pop = max((b.get("pop", 0) for b in blocks), default=0)
+
+            # Format date as "Mon 10 Feb"
+            date_obj = datetime.strptime(date_str, "%Y-%m-%d")
+            date_label = date_obj.strftime("%a %d %b")
+
+            line = f"{date_label}: {low:.0f}-{high:.0f}{t_unit}, {condition}"
+            if max_pop > 0.2:
+                line += f" ({max_pop:.0%} precip)"
+            day_lines.append(line)
+
+        if not day_lines:
+            return f"No forecast data available for {location_str}."
+
+        header = f"{days}-day forecast for {location_str}:"
+        return header + "\n\n" + "\n".join(day_lines)
+
+    def _temp_unit(self, units: str) -> str:
+        """Return the temperature unit symbol."""
+        return "\u00b0F" if units == "imperial" else "\u00b0C"
+
+    def _speed_unit(self, units: str) -> str:
+        """Return the wind speed unit."""
+        return "mph" if units == "imperial" else "m/s"


### PR DESCRIPTION
## Summary
Add OpenWeatherMap integration to Nanobot for current weather conditions and multi-day forecasts (up to 5 days). The tool aggregates 3-hour forecast blocks into daily summaries and supports both metric (Celsius) and imperial (Fahrenheit) units.

## Implementation Details
- Follows the optional tool registration pattern from HomeAssistantTool
- Configuration via Settings layer (not env vars)
- Proper aiohttp session lifecycle management with cleanup on shutdown
- Comprehensive test suite with mocked API responses (no real API key required)

## Test Plan
- [x] Unit tests for current weather and forecast endpoints
- [x] Error handling (404 location not found, 401 invalid key, timeouts)
- [x] Forecast aggregation and day limiting
- [x] Both metric and imperial unit systems
- [x] Tool schema validation

Closes #41