### PR TITLE
Build Radarr Tool

### DIFF
--- a/nanobot/.env.example
+++ b/nanobot/.env.example
@@ -100,6 +100,16 @@ GOOGLE_REDIRECT_URI=http://localhost:8000/api/oauth/google/callback
 OAUTH_FRONTEND_URL=http://localhost:5173
 
 # ===================
+# Radarr (optional — for movie library management)
+# ===================
+
+# Radarr server URL (container name on homeserver Docker network)
+RADARR_URL=http://radarr:7878
+
+# API key from Radarr: Settings > General > Security
+RADARR_API_KEY=
+
+# ===================
 # Cloudflare Tunnel (for Alexa → Home Assistant)
 # ===================
 

--- a/nanobot/api/config.py
+++ b/nanobot/api/config.py
@@ -34,6 +34,10 @@ class Settings(BaseSettings):
     # Weather (OpenWeatherMap)
     openweathermap_api_key: str = ""
 
+    # Radarr (movie management)
+    radarr_url: str = ""
+    radarr_api_key: str = ""
+
     # Service-to-service auth (LiveKit Agents -> butler-api)
     internal_api_key: str = ""
 

--- a/nanobot/api/deps.py
+++ b/nanobot/api/deps.py
@@ -16,6 +16,7 @@ from tools import (
     GoogleCalendarTool,
     HomeAssistantTool,
     ListEntitiesByDomainTool,
+    RadarrTool,
     RecallFactsTool,
     RememberFactTool,
     GetUserTool,
@@ -57,6 +58,13 @@ async def init_resources() -> None:
     if settings.openweathermap_api_key:
         _tools["weather"] = WeatherTool(
             api_key=settings.openweathermap_api_key,
+        )
+
+    # Only register Radarr tool if configured
+    if settings.radarr_url:
+        _tools["radarr"] = RadarrTool(
+            base_url=settings.radarr_url,
+            api_key=settings.radarr_api_key,
         )
 
 

--- a/nanobot/docker-compose.yml
+++ b/nanobot/docker-compose.yml
@@ -67,6 +67,9 @@ services:
       - HOME_ASSISTANT_TOKEN=${HA_TOKEN:-}
       # Weather
       - OPENWEATHERMAP_API_KEY=${OPENWEATHERMAP_API_KEY:-}
+      # Radarr
+      - RADARR_URL=http://radarr:7878
+      - RADARR_API_KEY=${RADARR_API_KEY:-}
       # Google OAuth (for Calendar, Gmail, etc.)
       - GOOGLE_CLIENT_ID=${GOOGLE_CLIENT_ID:-}
       - GOOGLE_CLIENT_SECRET=${GOOGLE_CLIENT_SECRET:-}

--- a/nanobot/tools/__init__.py
+++ b/nanobot/tools/__init__.py
@@ -29,6 +29,7 @@ from .memory import (
 )
 from .home_assistant import HomeAssistantTool, ListEntitiesByDomainTool
 from .google_calendar import GoogleCalendarTool
+from .radarr import RadarrTool
 from .weather import WeatherTool
 
 __all__ = [
@@ -49,6 +50,8 @@ __all__ = [
     "ListEntitiesByDomainTool",
     # Google Calendar
     "GoogleCalendarTool",
+    # Radarr
+    "RadarrTool",
     # Weather
     "WeatherTool",
 ]

--- a/nanobot/tools/radarr.py
+++ b/nanobot/tools/radarr.py
@@ -1,0 +1,434 @@
+"""Radarr integration tool for Butler.
+
+This tool allows the agent to manage movies via Radarr's REST API,
+enabling voice and text-based movie library management.
+
+Usage:
+    The tool is automatically registered when RADARR_URL is configured.
+    Requires RADARR_URL and RADARR_API_KEY in the application settings.
+
+Example:
+    tool = RadarrTool(base_url="http://radarr:7878", api_key="abc123")
+    result = await tool.execute(action="search_movie", title="Inception")
+
+    # When shutting down
+    await tool.close()
+
+API Reference:
+    https://radarr.video/docs/api/
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import aiohttp
+
+from .base import Tool
+
+# Default timeout for HTTP requests (seconds)
+DEFAULT_TIMEOUT = 10
+
+
+class RadarrTool(Tool):
+    """Manage movies in Radarr via REST API.
+
+    Supports searching TMDB for movies, adding them to the library,
+    checking library status, deleting movies, and viewing the download queue.
+
+    The tool reuses HTTP sessions for better performance and
+    caches quality profiles / root folders to minimise API calls.
+    """
+
+    def __init__(
+        self,
+        base_url: str | None = None,
+        api_key: str | None = None,
+        timeout: int = DEFAULT_TIMEOUT,
+    ):
+        """Initialize the Radarr tool.
+
+        Args:
+            base_url: Radarr URL (e.g. http://radarr:7878)
+            api_key: Radarr API key (Settings > General > Security)
+            timeout: HTTP request timeout in seconds (default: 10)
+        """
+        self.base_url = (base_url or "").rstrip("/")
+        self.api_key = api_key or ""
+        self.timeout = aiohttp.ClientTimeout(total=timeout)
+        self._session: aiohttp.ClientSession | None = None
+        # Cached config for auto-detection
+        self._quality_profiles: list[dict] | None = None
+        self._root_folders: list[dict] | None = None
+
+    async def _get_session(self) -> aiohttp.ClientSession:
+        """Get or create the HTTP session."""
+        if self._session is None or self._session.closed:
+            self._session = aiohttp.ClientSession(
+                headers={"X-Api-Key": self.api_key},
+                timeout=self.timeout,
+            )
+        return self._session
+
+    async def close(self) -> None:
+        """Close the HTTP session.
+
+        Should be called when shutting down to cleanly release connections.
+        """
+        if self._session and not self._session.closed:
+            await self._session.close()
+            self._session = None
+
+    # ------------------------------------------------------------------
+    # Tool interface
+    # ------------------------------------------------------------------
+
+    @property
+    def name(self) -> str:
+        return "radarr"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Manage movies in Radarr. Search for movies on TMDB, add them to "
+            "your library, check if a movie exists and its download status, "
+            "view active downloads, or delete movies from your collection."
+        )
+
+    @property
+    def parameters(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "action": {
+                    "type": "string",
+                    "enum": [
+                        "search_movie",
+                        "add_movie",
+                        "check_library",
+                        "delete_movie",
+                        "get_queue",
+                    ],
+                    "description": (
+                        "search_movie: Find movies on TMDB. "
+                        "add_movie: Add a movie (needs tmdb_id from search). "
+                        "check_library: Check if a movie exists and its status. "
+                        "delete_movie: Remove a movie (needs movie_id from check). "
+                        "get_queue: Show active downloads with progress."
+                    ),
+                },
+                "title": {
+                    "type": "string",
+                    "description": (
+                        "Movie title to search for. "
+                        "Used by search_movie, add_movie, and check_library."
+                    ),
+                },
+                "tmdb_id": {
+                    "type": "integer",
+                    "description": (
+                        "TMDB ID from search results. Required for add_movie."
+                    ),
+                },
+                "movie_id": {
+                    "type": "integer",
+                    "description": (
+                        "Radarr movie ID from check_library results. "
+                        "Required for delete_movie."
+                    ),
+                },
+                "delete_files": {
+                    "type": "boolean",
+                    "description": (
+                        "Also delete movie files from disk (default: false). "
+                        "Only used with delete_movie."
+                    ),
+                },
+            },
+            "required": ["action"],
+        }
+
+    async def execute(self, **kwargs: Any) -> str:
+        action = kwargs["action"]
+
+        if not self.base_url or not self.api_key:
+            return "Error: RADARR_URL and RADARR_API_KEY must be configured."
+
+        try:
+            if action == "search_movie":
+                return await self._search_movie(kwargs.get("title", ""))
+            elif action == "add_movie":
+                return await self._add_movie(
+                    tmdb_id=kwargs.get("tmdb_id"),
+                    title=kwargs.get("title", ""),
+                )
+            elif action == "check_library":
+                return await self._check_library(kwargs.get("title", ""))
+            elif action == "delete_movie":
+                return await self._delete_movie(
+                    movie_id=kwargs.get("movie_id"),
+                    delete_files=kwargs.get("delete_files", False),
+                )
+            elif action == "get_queue":
+                return await self._get_queue()
+            else:
+                return f"Error: Unknown action '{action}'"
+        except aiohttp.ClientError as e:
+            return f"Error connecting to Radarr: {e}"
+        except TimeoutError:
+            return "Error: Radarr request timed out"
+        except Exception as e:
+            return f"Error: {e}"
+
+    # ------------------------------------------------------------------
+    # Actions
+    # ------------------------------------------------------------------
+
+    async def _search_movie(self, title: str) -> str:
+        """Search TMDB for movies via Radarr's lookup endpoint."""
+        if not title:
+            return "Error: title is required for search_movie"
+
+        session = await self._get_session()
+        url = f"{self.base_url}/api/v3/movie/lookup"
+
+        async with session.get(url, params={"term": title}) as resp:
+            if resp.status == 401:
+                return "Error: Invalid Radarr API key."
+            if resp.status != 200:
+                return f"Error: HTTP {resp.status}"
+
+            results = await resp.json()
+            if not results or not isinstance(results, list):
+                return f"No movies found for '{title}'"
+
+            return self._format_search_results(results[:5], title)
+
+    async def _add_movie(
+        self,
+        tmdb_id: int | None,
+        title: str,
+    ) -> str:
+        """Add a movie to Radarr using its TMDB ID."""
+        if not tmdb_id:
+            return "Error: tmdb_id is required for add_movie (get it from search_movie)"
+
+        session = await self._get_session()
+
+        # Fetch full movie data from TMDB via Radarr
+        lookup_url = f"{self.base_url}/api/v3/movie/lookup/tmdb"
+        async with session.get(lookup_url, params={"tmdbId": tmdb_id}) as resp:
+            if resp.status != 200:
+                return f"Error fetching movie details: HTTP {resp.status}"
+            movie_data = await resp.json()
+
+        if not movie_data or not isinstance(movie_data, dict):
+            return f"Error: Could not find movie data for TMDB ID {tmdb_id}."
+
+        # Auto-detect quality profile and root folder
+        quality_profile_id = await self._get_default_quality_profile_id()
+        if quality_profile_id is None:
+            return "Error: No quality profiles configured in Radarr."
+
+        root_folder_path = await self._get_default_root_folder()
+        if root_folder_path is None:
+            return "Error: No root folders configured in Radarr."
+
+        # Build payload
+        payload = {
+            **movie_data,
+            "qualityProfileId": quality_profile_id,
+            "rootFolderPath": root_folder_path,
+            "monitored": True,
+            "addOptions": {"searchForMovie": True},
+        }
+
+        async with session.post(
+            f"{self.base_url}/api/v3/movie", json=payload
+        ) as resp:
+            if resp.status in (200, 201):
+                result = await resp.json()
+                movie_title = result.get("title", title or "Movie")
+                year = result.get("year", "")
+                return f"Added '{movie_title}' ({year}) to Radarr. Searching for releases now."
+            elif resp.status == 400:
+                error = await resp.text()
+                if "already" in error.lower():
+                    return f"'{title or 'This movie'}' is already in your library."
+                return f"Error adding movie: {error}"
+            else:
+                return f"Error: HTTP {resp.status}"
+
+    async def _check_library(self, title: str) -> str:
+        """Check if a movie exists in the Radarr library."""
+        if not title:
+            return "Error: title is required for check_library"
+
+        session = await self._get_session()
+
+        async with session.get(f"{self.base_url}/api/v3/movie") as resp:
+            if resp.status == 401:
+                return "Error: Invalid Radarr API key."
+            if resp.status != 200:
+                return f"Error: HTTP {resp.status}"
+
+            movies = await resp.json()
+
+        # Case-insensitive partial match
+        title_lower = title.lower()
+        matches = [
+            m for m in movies if title_lower in m.get("title", "").lower()
+        ]
+
+        if not matches:
+            return f"'{title}' not found in library."
+
+        return self._format_library_results(matches[:5])
+
+    async def _delete_movie(
+        self,
+        movie_id: int | None,
+        delete_files: bool,
+    ) -> str:
+        """Delete a movie from Radarr."""
+        if not movie_id:
+            return "Error: movie_id is required for delete_movie (get it from check_library)"
+
+        session = await self._get_session()
+        url = f"{self.base_url}/api/v3/movie/{movie_id}"
+        params = {"deleteFiles": str(delete_files).lower()}
+
+        async with session.delete(url, params=params) as resp:
+            if resp.status in (200, 204):
+                files_note = " and deleted files from disk" if delete_files else ""
+                return f"Removed movie (ID {movie_id}) from Radarr{files_note}."
+            elif resp.status == 404:
+                return f"Error: Movie ID {movie_id} not found in Radarr."
+            else:
+                return f"Error: HTTP {resp.status}"
+
+    async def _get_queue(self) -> str:
+        """Get active downloads from the Radarr queue."""
+        session = await self._get_session()
+
+        async with session.get(f"{self.base_url}/api/v3/queue") as resp:
+            if resp.status == 401:
+                return "Error: Invalid Radarr API key."
+            if resp.status != 200:
+                return f"Error: HTTP {resp.status}"
+
+            data = await resp.json()
+
+        records = data.get("records", [])
+        if not records:
+            return "Download queue is empty."
+
+        return self._format_queue(records)
+
+    # ------------------------------------------------------------------
+    # Auto-detection helpers (cached)
+    # ------------------------------------------------------------------
+
+    async def _get_default_quality_profile_id(self) -> int | None:
+        """Return the first quality profile ID, caching after first call."""
+        if self._quality_profiles is None:
+            session = await self._get_session()
+            async with session.get(
+                f"{self.base_url}/api/v3/qualityprofile"
+            ) as resp:
+                if resp.status != 200:
+                    return None
+                self._quality_profiles = await resp.json()
+
+        if self._quality_profiles:
+            return self._quality_profiles[0].get("id")
+        return None
+
+    async def _get_default_root_folder(self) -> str | None:
+        """Return the first root folder path, caching after first call."""
+        if self._root_folders is None:
+            session = await self._get_session()
+            async with session.get(
+                f"{self.base_url}/api/v3/rootfolder"
+            ) as resp:
+                if resp.status != 200:
+                    return None
+                self._root_folders = await resp.json()
+
+        if self._root_folders:
+            return self._root_folders[0].get("path")
+        return None
+
+    # ------------------------------------------------------------------
+    # Formatting helpers
+    # ------------------------------------------------------------------
+
+    def _format_search_results(self, results: list[dict], query: str) -> str:
+        """Format TMDB search results for LLM consumption."""
+        lines = [f"Found {len(results)} result(s) for '{query}':\n"]
+        for i, movie in enumerate(results, 1):
+            title = movie.get("title", "Unknown")
+            year = movie.get("year", "")
+            tmdb_id = movie.get("tmdbId", "?")
+            overview = movie.get("overview", "")
+            # Truncate overview to keep response concise
+            if len(overview) > 100:
+                overview = overview[:100] + "..."
+
+            lines.append(f"{i}. {title} ({year}) [TMDB: {tmdb_id}]")
+            if overview:
+                lines.append(f"   {overview}")
+        return "\n".join(lines)
+
+    def _format_library_results(self, movies: list[dict]) -> str:
+        """Format library matches for LLM consumption."""
+        lines = []
+        for movie in movies:
+            title = movie.get("title", "Unknown")
+            year = movie.get("year", "")
+            movie_id = movie.get("id", "?")
+            monitored = "Monitored" if movie.get("monitored") else "Unmonitored"
+            has_file = movie.get("hasFile", False)
+
+            if has_file:
+                movie_file = movie.get("movieFile") or {}
+                quality_name = (
+                    movie_file.get("quality", {})
+                    .get("quality", {})
+                    .get("name", "Unknown")
+                )
+                size_bytes = movie_file.get("size") or 0
+                size_gb = size_bytes / (1024 ** 3)
+                lines.append(f"{title} ({year}) [ID: {movie_id}]")
+                lines.append(
+                    f"  Status: Downloaded - {quality_name} ({size_gb:.1f} GB)"
+                )
+            else:
+                lines.append(f"{title} ({year}) [ID: {movie_id}]")
+                lines.append("  Status: Missing")
+
+            lines.append(f"  {monitored}")
+            lines.append("")
+
+        return "\n".join(lines).rstrip()
+
+    def _format_queue(self, records: list[dict]) -> str:
+        """Format download queue for LLM consumption."""
+        lines = [f"Active downloads ({len(records)}):\n"]
+        for item in records:
+            title = item.get("title", "Unknown")
+            status = item.get("status", "unknown")
+            size = item.get("size") or 0
+            size_left = item.get("sizeleft") or 0
+            time_left = item.get("timeleft", "unknown")
+
+            if size > 0:
+                progress_pct = ((size - size_left) / size) * 100
+            else:
+                progress_pct = 0.0
+
+            lines.append(f"- {title}")
+            lines.append(
+                f"  {status} - {progress_pct:.1f}% complete (ETA: {time_left})"
+            )
+        return "\n".join(lines)

--- a/nanobot/tools/test_radarr.py
+++ b/nanobot/tools/test_radarr.py
@@ -1,0 +1,430 @@
+"""Tests for Radarr tool.
+
+Run with: pytest nanobot/tools/test_radarr.py -v
+
+These tests use mocked responses — no real Radarr instance required.
+"""
+
+import pytest
+import aiohttp
+from unittest.mock import AsyncMock, patch
+
+from .radarr import RadarrTool
+
+
+# ---------------------------------------------------------------------------
+# Sample API responses for mocking
+# ---------------------------------------------------------------------------
+
+SAMPLE_SEARCH_RESULTS = [
+    {
+        "title": "Inception",
+        "year": 2010,
+        "tmdbId": 27205,
+        "overview": "A thief who steals corporate secrets through dream-sharing technology is given the task of planting an idea.",
+    },
+    {
+        "title": "Inception: The Cobol Job",
+        "year": 2010,
+        "tmdbId": 72007,
+        "overview": "A prequel comic to the film Inception.",
+    },
+]
+
+SAMPLE_MOVIE_LOOKUP = {
+    "title": "Inception",
+    "year": 2010,
+    "tmdbId": 27205,
+    "overview": "A thief who steals corporate secrets...",
+}
+
+SAMPLE_ADD_RESPONSE = {
+    "id": 1,
+    "title": "Inception",
+    "year": 2010,
+    "tmdbId": 27205,
+    "path": "/movies/Inception (2010)",
+}
+
+SAMPLE_LIBRARY = [
+    {
+        "id": 1,
+        "title": "Inception",
+        "year": 2010,
+        "hasFile": True,
+        "monitored": True,
+        "movieFile": {
+            "quality": {"quality": {"name": "Bluray-1080p"}},
+            "size": 8589934592,  # ~8 GB
+        },
+    },
+    {
+        "id": 2,
+        "title": "The Dark Knight",
+        "year": 2008,
+        "hasFile": False,
+        "monitored": True,
+        "movieFile": None,
+    },
+]
+
+SAMPLE_QUALITY_PROFILES = [
+    {"id": 4, "name": "HD-1080p"},
+    {"id": 6, "name": "Ultra-HD"},
+]
+
+SAMPLE_ROOT_FOLDERS = [
+    {"id": 1, "path": "/movies"},
+]
+
+SAMPLE_QUEUE = {
+    "records": [
+        {
+            "title": "The Matrix (1999) Bluray-1080p",
+            "status": "downloading",
+            "size": 5368709120,
+            "sizeleft": 1073741824,
+            "timeleft": "00:15:30",
+        },
+    ],
+}
+
+SAMPLE_QUEUE_EMPTY = {"records": []}
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def tool():
+    """Create a tool instance with test config."""
+    return RadarrTool(base_url="http://radarr:7878", api_key="test_key_123")
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestRadarrToolProperties:
+    """Verify tool metadata."""
+
+    def test_name(self, tool):
+        assert tool.name == "radarr"
+
+    def test_description_mentions_movies(self, tool):
+        assert "movie" in tool.description.lower()
+
+    def test_parameters_has_action(self, tool):
+        props = tool.parameters["properties"]
+        assert "action" in props
+        assert set(props["action"]["enum"]) == {
+            "search_movie",
+            "add_movie",
+            "check_library",
+            "delete_movie",
+            "get_queue",
+        }
+
+    def test_required_fields(self, tool):
+        assert tool.parameters["required"] == ["action"]
+
+    def test_to_schema(self, tool):
+        schema = tool.to_schema()
+        assert schema["type"] == "function"
+        assert schema["function"]["name"] == "radarr"
+        assert "parameters" in schema["function"]
+
+
+class TestMissingConfig:
+    """Error when Radarr is not configured."""
+
+    @pytest.mark.asyncio
+    async def test_missing_url(self):
+        tool = RadarrTool(base_url="", api_key="key")
+        result = await tool.execute(action="search_movie", title="test")
+        assert "must be configured" in result
+
+    @pytest.mark.asyncio
+    async def test_missing_api_key(self):
+        tool = RadarrTool(base_url="http://radarr:7878", api_key="")
+        result = await tool.execute(action="search_movie", title="test")
+        assert "must be configured" in result
+
+
+class TestSearchMovie:
+    """Tests for the search_movie action."""
+
+    @pytest.mark.asyncio
+    async def test_search_returns_results(self, tool):
+        with patch("tools.radarr.aiohttp.ClientSession") as mock_cls:
+            mock_resp = AsyncMock()
+            mock_resp.status = 200
+            mock_resp.json = AsyncMock(return_value=SAMPLE_SEARCH_RESULTS)
+            mock_cls.return_value.get.return_value.__aenter__.return_value = mock_resp
+
+            result = await tool.execute(action="search_movie", title="Inception")
+
+            assert "Inception" in result
+            assert "2010" in result
+            assert "27205" in result
+            assert "2 result(s)" in result
+
+    @pytest.mark.asyncio
+    async def test_search_no_results(self, tool):
+        with patch("tools.radarr.aiohttp.ClientSession") as mock_cls:
+            mock_resp = AsyncMock()
+            mock_resp.status = 200
+            mock_resp.json = AsyncMock(return_value=[])
+            mock_cls.return_value.get.return_value.__aenter__.return_value = mock_resp
+
+            result = await tool.execute(action="search_movie", title="Nonexistentmovie123")
+
+            assert "No movies found" in result
+
+    @pytest.mark.asyncio
+    async def test_search_missing_title(self, tool):
+        result = await tool.execute(action="search_movie")
+        assert "title is required" in result
+
+    @pytest.mark.asyncio
+    async def test_search_invalid_api_key(self, tool):
+        with patch("tools.radarr.aiohttp.ClientSession") as mock_cls:
+            mock_resp = AsyncMock()
+            mock_resp.status = 401
+            mock_cls.return_value.get.return_value.__aenter__.return_value = mock_resp
+
+            result = await tool.execute(action="search_movie", title="Inception")
+
+            assert "Invalid" in result
+
+
+class TestAddMovie:
+    """Tests for the add_movie action."""
+
+    @pytest.mark.asyncio
+    async def test_add_success(self, tool):
+        with patch("tools.radarr.aiohttp.ClientSession") as mock_cls:
+            mock_session = mock_cls.return_value
+
+            # Sequence: lookup → qualityprofile → rootfolder → add
+            lookup_resp = AsyncMock(status=200)
+            lookup_resp.json = AsyncMock(return_value=SAMPLE_MOVIE_LOOKUP)
+
+            profile_resp = AsyncMock(status=200)
+            profile_resp.json = AsyncMock(return_value=SAMPLE_QUALITY_PROFILES)
+
+            folder_resp = AsyncMock(status=200)
+            folder_resp.json = AsyncMock(return_value=SAMPLE_ROOT_FOLDERS)
+
+            add_resp = AsyncMock(status=201)
+            add_resp.json = AsyncMock(return_value=SAMPLE_ADD_RESPONSE)
+
+            mock_session.get.return_value.__aenter__.side_effect = [
+                lookup_resp,
+                profile_resp,
+                folder_resp,
+            ]
+            mock_session.post.return_value.__aenter__.return_value = add_resp
+
+            result = await tool.execute(action="add_movie", tmdb_id=27205)
+
+            assert "Added" in result
+            assert "Inception" in result
+            assert "2010" in result
+
+    @pytest.mark.asyncio
+    async def test_add_missing_tmdb_id(self, tool):
+        result = await tool.execute(action="add_movie", title="Inception")
+        assert "tmdb_id is required" in result
+
+    @pytest.mark.asyncio
+    async def test_add_already_exists(self, tool):
+        with patch("tools.radarr.aiohttp.ClientSession") as mock_cls:
+            mock_session = mock_cls.return_value
+
+            lookup_resp = AsyncMock(status=200)
+            lookup_resp.json = AsyncMock(return_value=SAMPLE_MOVIE_LOOKUP)
+
+            profile_resp = AsyncMock(status=200)
+            profile_resp.json = AsyncMock(return_value=SAMPLE_QUALITY_PROFILES)
+
+            folder_resp = AsyncMock(status=200)
+            folder_resp.json = AsyncMock(return_value=SAMPLE_ROOT_FOLDERS)
+
+            add_resp = AsyncMock(status=400)
+            add_resp.text = AsyncMock(
+                return_value='[{"errorMessage":"This movie has already been added"}]'
+            )
+
+            mock_session.get.return_value.__aenter__.side_effect = [
+                lookup_resp,
+                profile_resp,
+                folder_resp,
+            ]
+            mock_session.post.return_value.__aenter__.return_value = add_resp
+
+            result = await tool.execute(action="add_movie", tmdb_id=27205)
+
+            assert "already" in result.lower()
+
+
+class TestCheckLibrary:
+    """Tests for the check_library action."""
+
+    @pytest.mark.asyncio
+    async def test_check_found_downloaded(self, tool):
+        with patch("tools.radarr.aiohttp.ClientSession") as mock_cls:
+            mock_resp = AsyncMock()
+            mock_resp.status = 200
+            mock_resp.json = AsyncMock(return_value=SAMPLE_LIBRARY)
+            mock_cls.return_value.get.return_value.__aenter__.return_value = mock_resp
+
+            result = await tool.execute(action="check_library", title="Inception")
+
+            assert "Inception" in result
+            assert "Downloaded" in result
+            assert "Bluray-1080p" in result
+            assert "8.0 GB" in result
+
+    @pytest.mark.asyncio
+    async def test_check_found_missing(self, tool):
+        with patch("tools.radarr.aiohttp.ClientSession") as mock_cls:
+            mock_resp = AsyncMock()
+            mock_resp.status = 200
+            mock_resp.json = AsyncMock(return_value=SAMPLE_LIBRARY)
+            mock_cls.return_value.get.return_value.__aenter__.return_value = mock_resp
+
+            result = await tool.execute(action="check_library", title="Dark Knight")
+
+            assert "Dark Knight" in result
+            assert "Missing" in result
+
+    @pytest.mark.asyncio
+    async def test_check_not_in_library(self, tool):
+        with patch("tools.radarr.aiohttp.ClientSession") as mock_cls:
+            mock_resp = AsyncMock()
+            mock_resp.status = 200
+            mock_resp.json = AsyncMock(return_value=SAMPLE_LIBRARY)
+            mock_cls.return_value.get.return_value.__aenter__.return_value = mock_resp
+
+            result = await tool.execute(action="check_library", title="Nonexistent")
+
+            assert "not found in library" in result
+
+    @pytest.mark.asyncio
+    async def test_check_missing_title(self, tool):
+        result = await tool.execute(action="check_library")
+        assert "title is required" in result
+
+
+class TestDeleteMovie:
+    """Tests for the delete_movie action."""
+
+    @pytest.mark.asyncio
+    async def test_delete_success(self, tool):
+        with patch("tools.radarr.aiohttp.ClientSession") as mock_cls:
+            mock_resp = AsyncMock()
+            mock_resp.status = 200
+            mock_cls.return_value.delete.return_value.__aenter__.return_value = mock_resp
+
+            result = await tool.execute(action="delete_movie", movie_id=1)
+
+            assert "Removed" in result
+
+    @pytest.mark.asyncio
+    async def test_delete_with_files(self, tool):
+        with patch("tools.radarr.aiohttp.ClientSession") as mock_cls:
+            mock_resp = AsyncMock()
+            mock_resp.status = 200
+            mock_cls.return_value.delete.return_value.__aenter__.return_value = mock_resp
+
+            result = await tool.execute(
+                action="delete_movie", movie_id=1, delete_files=True
+            )
+
+            assert "deleted files from disk" in result
+
+    @pytest.mark.asyncio
+    async def test_delete_not_found(self, tool):
+        with patch("tools.radarr.aiohttp.ClientSession") as mock_cls:
+            mock_resp = AsyncMock()
+            mock_resp.status = 404
+            mock_cls.return_value.delete.return_value.__aenter__.return_value = mock_resp
+
+            result = await tool.execute(action="delete_movie", movie_id=999)
+
+            assert "not found" in result
+
+    @pytest.mark.asyncio
+    async def test_delete_missing_id(self, tool):
+        result = await tool.execute(action="delete_movie")
+        assert "movie_id is required" in result
+
+
+class TestGetQueue:
+    """Tests for the get_queue action."""
+
+    @pytest.mark.asyncio
+    async def test_queue_with_items(self, tool):
+        with patch("tools.radarr.aiohttp.ClientSession") as mock_cls:
+            mock_resp = AsyncMock()
+            mock_resp.status = 200
+            mock_resp.json = AsyncMock(return_value=SAMPLE_QUEUE)
+            mock_cls.return_value.get.return_value.__aenter__.return_value = mock_resp
+
+            result = await tool.execute(action="get_queue")
+
+            assert "Matrix" in result
+            assert "downloading" in result
+            assert "80.0%" in result
+            assert "00:15:30" in result
+
+    @pytest.mark.asyncio
+    async def test_queue_empty(self, tool):
+        with patch("tools.radarr.aiohttp.ClientSession") as mock_cls:
+            mock_resp = AsyncMock()
+            mock_resp.status = 200
+            mock_resp.json = AsyncMock(return_value=SAMPLE_QUEUE_EMPTY)
+            mock_cls.return_value.get.return_value.__aenter__.return_value = mock_resp
+
+            result = await tool.execute(action="get_queue")
+
+            assert "empty" in result.lower()
+
+
+class TestErrorHandling:
+    """Tests for error handling."""
+
+    @pytest.mark.asyncio
+    async def test_unknown_action(self, tool):
+        result = await tool.execute(action="explode")
+        assert "Unknown action" in result
+
+    @pytest.mark.asyncio
+    async def test_connection_error(self, tool):
+        with patch("tools.radarr.aiohttp.ClientSession") as mock_cls:
+            mock_cls.return_value.get.return_value.__aenter__.side_effect = (
+                aiohttp.ClientError("Connection refused")
+            )
+
+            result = await tool.execute(action="search_movie", title="test")
+
+            assert "Error" in result
+
+    @pytest.mark.asyncio
+    async def test_timeout_error(self, tool):
+        with patch("tools.radarr.aiohttp.ClientSession") as mock_cls:
+            mock_cls.return_value.get.return_value.__aenter__.side_effect = (
+                TimeoutError()
+            )
+
+            result = await tool.execute(action="search_movie", title="test")
+
+            assert "timed out" in result
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
Closes #5

## Summary
- Add `RadarrTool` — a single-tool, 5-action Python class for managing movies via Radarr's REST API
- Actions: `search_movie`, `add_movie`, `check_library`, `delete_movie`, `get_queue`
- Auto-detects quality profile and root folder from Radarr config (cached after first call)
- Follows existing WeatherTool / HomeAssistantTool patterns (aiohttp session reuse, string returns, conditional registration)
- 27 unit tests covering all actions, error handling, and edge cases
- Registered conditionally in `deps.py` when `RADARR_URL` is set
- Environment variables added to `.env.example` and `docker-compose.yml`

## Files changed
- **New:** `nanobot/tools/radarr.py` (434 lines) — RadarrTool implementation
- **New:** `nanobot/tools/test_radarr.py` (430 lines) — test suite
- **Modified:** `nanobot/api/config.py` — add `radarr_url`, `radarr_api_key` settings
- **Modified:** `nanobot/api/deps.py` — import + conditional registration
- **Modified:** `nanobot/tools/__init__.py` — export RadarrTool
- **Modified:** `nanobot/.env.example` — document Radarr config
- **Modified:** `nanobot/docker-compose.yml` — pass env vars to butler-api

## Test plan
- [x] All 27 Radarr tests pass
- [x] All 14 existing Weather tests still pass (no regression)
- [ ] Manual test with real Radarr instance after deployment