### PR TITLE
Build Sonarr Tool for TV series management

### DIFF
--- a/nanobot/.env.example
+++ b/nanobot/.env.example
@@ -110,6 +110,16 @@ RADARR_URL=http://radarr:7878
 RADARR_API_KEY=
 
 # ===================
+# Sonarr (optional — for TV series library management)
+# ===================
+
+# Sonarr server URL (container name on homeserver Docker network)
+SONARR_URL=http://sonarr:8989
+
+# API key from Sonarr: Settings > General > Security
+SONARR_API_KEY=
+
+# ===================
 # Cloudflare Tunnel (for Alexa → Home Assistant)
 # ===================
 

--- a/nanobot/api/config.py
+++ b/nanobot/api/config.py
@@ -38,6 +38,10 @@ class Settings(BaseSettings):
     radarr_url: str = ""
     radarr_api_key: str = ""
 
+    # Sonarr (TV series management)
+    sonarr_url: str = ""
+    sonarr_api_key: str = ""
+
     # Service-to-service auth (LiveKit Agents -> butler-api)
     internal_api_key: str = ""
 

--- a/nanobot/api/deps.py
+++ b/nanobot/api/deps.py
@@ -20,6 +20,7 @@ from tools import (
     RecallFactsTool,
     RememberFactTool,
     GetUserTool,
+    SonarrTool,
     Tool,
     WeatherTool,
 )
@@ -65,6 +66,13 @@ async def init_resources() -> None:
         _tools["radarr"] = RadarrTool(
             base_url=settings.radarr_url,
             api_key=settings.radarr_api_key,
+        )
+
+    # Only register Sonarr tool if configured
+    if settings.sonarr_url:
+        _tools["sonarr"] = SonarrTool(
+            base_url=settings.sonarr_url,
+            api_key=settings.sonarr_api_key,
         )
 
 

--- a/nanobot/tools/__init__.py
+++ b/nanobot/tools/__init__.py
@@ -30,6 +30,7 @@ from .memory import (
 from .home_assistant import HomeAssistantTool, ListEntitiesByDomainTool
 from .google_calendar import GoogleCalendarTool
 from .radarr import RadarrTool
+from .sonarr import SonarrTool
 from .weather import WeatherTool
 
 __all__ = [
@@ -52,6 +53,8 @@ __all__ = [
     "GoogleCalendarTool",
     # Radarr
     "RadarrTool",
+    # Sonarr
+    "SonarrTool",
     # Weather
     "WeatherTool",
 ]

--- a/nanobot/tools/sonarr.py
+++ b/nanobot/tools/sonarr.py
@@ -1,0 +1,440 @@
+"""Sonarr integration tool for Butler.
+
+This tool allows the agent to manage TV series via Sonarr's REST API,
+enabling voice and text-based TV library management.
+
+Usage:
+    The tool is automatically registered when SONARR_URL is configured.
+    Requires SONARR_URL and SONARR_API_KEY in the application settings.
+
+Example:
+    tool = SonarrTool(base_url="http://sonarr:8989", api_key="abc123")
+    result = await tool.execute(action="search_series", title="Breaking Bad")
+
+    # When shutting down
+    await tool.close()
+
+API Reference:
+    https://sonarr.tv/docs/api/
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import aiohttp
+
+from .base import Tool
+
+# Default timeout for HTTP requests (seconds)
+DEFAULT_TIMEOUT = 10
+
+
+class SonarrTool(Tool):
+    """Manage TV series in Sonarr via REST API.
+
+    Supports searching TVDB for series, adding them to the library,
+    checking library status, deleting series, and viewing the download queue.
+
+    The tool reuses HTTP sessions for better performance and
+    caches quality profiles / root folders to minimise API calls.
+    """
+
+    def __init__(
+        self,
+        base_url: str | None = None,
+        api_key: str | None = None,
+        timeout: int = DEFAULT_TIMEOUT,
+    ):
+        """Initialize the Sonarr tool.
+
+        Args:
+            base_url: Sonarr URL (e.g. http://sonarr:8989)
+            api_key: Sonarr API key (Settings > General > Security)
+            timeout: HTTP request timeout in seconds (default: 10)
+        """
+        self.base_url = (base_url or "").rstrip("/")
+        self.api_key = api_key or ""
+        self.timeout = aiohttp.ClientTimeout(total=timeout)
+        self._session: aiohttp.ClientSession | None = None
+        # Cached config for auto-detection
+        self._quality_profiles: list[dict] | None = None
+        self._root_folders: list[dict] | None = None
+
+    async def _get_session(self) -> aiohttp.ClientSession:
+        """Get or create the HTTP session."""
+        if self._session is None or self._session.closed:
+            self._session = aiohttp.ClientSession(
+                headers={"X-Api-Key": self.api_key},
+                timeout=self.timeout,
+            )
+        return self._session
+
+    async def close(self) -> None:
+        """Close the HTTP session.
+
+        Should be called when shutting down to cleanly release connections.
+        """
+        if self._session and not self._session.closed:
+            await self._session.close()
+            self._session = None
+
+    # ------------------------------------------------------------------
+    # Tool interface
+    # ------------------------------------------------------------------
+
+    @property
+    def name(self) -> str:
+        return "sonarr"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Manage TV series in Sonarr. Search for shows on TVDB, add them to "
+            "your library, check if a series exists and its download status, "
+            "view active downloads, or delete series from your collection."
+        )
+
+    @property
+    def parameters(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "action": {
+                    "type": "string",
+                    "enum": [
+                        "search_series",
+                        "add_series",
+                        "check_library",
+                        "delete_series",
+                        "get_queue",
+                    ],
+                    "description": (
+                        "search_series: Find TV shows on TVDB. "
+                        "add_series: Add a series (needs tvdb_id from search). "
+                        "check_library: Check if a series exists and its status. "
+                        "delete_series: Remove a series (needs series_id from check). "
+                        "get_queue: Show active downloads with progress."
+                    ),
+                },
+                "title": {
+                    "type": "string",
+                    "description": (
+                        "Series title to search for. "
+                        "Used by search_series, add_series, and check_library."
+                    ),
+                },
+                "tvdb_id": {
+                    "type": "integer",
+                    "description": (
+                        "TVDB ID from search results. Required for add_series."
+                    ),
+                },
+                "series_id": {
+                    "type": "integer",
+                    "description": (
+                        "Sonarr series ID from check_library results. "
+                        "Required for delete_series."
+                    ),
+                },
+                "delete_files": {
+                    "type": "boolean",
+                    "description": (
+                        "Also delete episode files from disk (default: false). "
+                        "Only used with delete_series."
+                    ),
+                },
+            },
+            "required": ["action"],
+        }
+
+    async def execute(self, **kwargs: Any) -> str:
+        action = kwargs["action"]
+
+        if not self.base_url or not self.api_key:
+            return "Error: SONARR_URL and SONARR_API_KEY must be configured."
+
+        try:
+            if action == "search_series":
+                return await self._search_series(kwargs.get("title", ""))
+            elif action == "add_series":
+                return await self._add_series(
+                    tvdb_id=kwargs.get("tvdb_id"),
+                    title=kwargs.get("title", ""),
+                )
+            elif action == "check_library":
+                return await self._check_library(kwargs.get("title", ""))
+            elif action == "delete_series":
+                return await self._delete_series(
+                    series_id=kwargs.get("series_id"),
+                    delete_files=kwargs.get("delete_files", False),
+                )
+            elif action == "get_queue":
+                return await self._get_queue()
+            else:
+                return f"Error: Unknown action '{action}'"
+        except aiohttp.ClientError as e:
+            return f"Error connecting to Sonarr: {e}"
+        except TimeoutError:
+            return "Error: Sonarr request timed out"
+        except Exception as e:
+            return f"Error: {e}"
+
+    # ------------------------------------------------------------------
+    # Actions
+    # ------------------------------------------------------------------
+
+    async def _search_series(self, title: str) -> str:
+        """Search TVDB for series via Sonarr's lookup endpoint."""
+        if not title:
+            return "Error: title is required for search_series"
+
+        session = await self._get_session()
+        url = f"{self.base_url}/api/v3/series/lookup"
+
+        async with session.get(url, params={"term": title}) as resp:
+            if resp.status == 401:
+                return "Error: Invalid Sonarr API key."
+            if resp.status != 200:
+                return f"Error: HTTP {resp.status}"
+
+            results = await resp.json()
+            if not results or not isinstance(results, list):
+                return f"No series found for '{title}'"
+
+            return self._format_search_results(results[:5], title)
+
+    async def _add_series(
+        self,
+        tvdb_id: int | None,
+        title: str,
+    ) -> str:
+        """Add a series to Sonarr using its TVDB ID."""
+        if not tvdb_id:
+            return "Error: tvdb_id is required for add_series (get it from search_series)"
+
+        session = await self._get_session()
+
+        # Fetch full series data from TVDB via Sonarr
+        lookup_url = f"{self.base_url}/api/v3/series/lookup"
+        async with session.get(lookup_url, params={"term": f"tvdb:{tvdb_id}"}) as resp:
+            if resp.status != 200:
+                return f"Error fetching series details: HTTP {resp.status}"
+            results = await resp.json()
+
+        if not results or not isinstance(results, list) or len(results) == 0:
+            return f"Error: Could not find series data for TVDB ID {tvdb_id}."
+
+        series_data = results[0]
+
+        # Auto-detect quality profile and root folder
+        quality_profile_id = await self._get_default_quality_profile_id()
+        if quality_profile_id is None:
+            return "Error: No quality profiles configured in Sonarr."
+
+        root_folder_path = await self._get_default_root_folder()
+        if root_folder_path is None:
+            return "Error: No root folders configured in Sonarr."
+
+        # Build payload
+        payload = {
+            **series_data,
+            "qualityProfileId": quality_profile_id,
+            "rootFolderPath": root_folder_path,
+            "monitored": True,
+            "addOptions": {"searchForMissingEpisodes": True},
+        }
+
+        async with session.post(
+            f"{self.base_url}/api/v3/series", json=payload
+        ) as resp:
+            if resp.status in (200, 201):
+                result = await resp.json()
+                series_title = result.get("title", title or "Series")
+                year = result.get("year", "")
+                season_count = result.get("seasonCount", 0)
+                seasons = f"{season_count} season{'s' if season_count != 1 else ''}"
+                return (
+                    f"Added '{series_title}' ({year}) to Sonarr ({seasons}). "
+                    f"Searching for missing episodes now."
+                )
+            elif resp.status == 400:
+                error = await resp.text()
+                if "already" in error.lower():
+                    return f"'{title or 'This series'}' is already in your library."
+                return f"Error adding series: {error}"
+            else:
+                return f"Error: HTTP {resp.status}"
+
+    async def _check_library(self, title: str) -> str:
+        """Check if a series exists in the Sonarr library."""
+        if not title:
+            return "Error: title is required for check_library"
+
+        session = await self._get_session()
+
+        async with session.get(f"{self.base_url}/api/v3/series") as resp:
+            if resp.status == 401:
+                return "Error: Invalid Sonarr API key."
+            if resp.status != 200:
+                return f"Error: HTTP {resp.status}"
+
+            series_list = await resp.json()
+
+        # Case-insensitive partial match
+        title_lower = title.lower()
+        matches = [
+            s for s in series_list if title_lower in s.get("title", "").lower()
+        ]
+
+        if not matches:
+            return f"'{title}' not found in library."
+
+        return self._format_library_results(matches[:5])
+
+    async def _delete_series(
+        self,
+        series_id: int | None,
+        delete_files: bool,
+    ) -> str:
+        """Delete a series from Sonarr."""
+        if not series_id:
+            return "Error: series_id is required for delete_series (get it from check_library)"
+
+        session = await self._get_session()
+        url = f"{self.base_url}/api/v3/series/{series_id}"
+        params = {"deleteFiles": str(delete_files).lower()}
+
+        async with session.delete(url, params=params) as resp:
+            if resp.status in (200, 204):
+                files_note = " and deleted files from disk" if delete_files else ""
+                return f"Removed series (ID {series_id}) from Sonarr{files_note}."
+            elif resp.status == 404:
+                return f"Error: Series ID {series_id} not found in Sonarr."
+            else:
+                return f"Error: HTTP {resp.status}"
+
+    async def _get_queue(self) -> str:
+        """Get active downloads from the Sonarr queue."""
+        session = await self._get_session()
+
+        async with session.get(f"{self.base_url}/api/v3/queue") as resp:
+            if resp.status == 401:
+                return "Error: Invalid Sonarr API key."
+            if resp.status != 200:
+                return f"Error: HTTP {resp.status}"
+
+            data = await resp.json()
+
+        records = data.get("records", [])
+        if not records:
+            return "Download queue is empty."
+
+        return self._format_queue(records)
+
+    # ------------------------------------------------------------------
+    # Auto-detection helpers (cached)
+    # ------------------------------------------------------------------
+
+    async def _get_default_quality_profile_id(self) -> int | None:
+        """Return the first quality profile ID, caching after first call."""
+        if self._quality_profiles is None:
+            session = await self._get_session()
+            async with session.get(
+                f"{self.base_url}/api/v3/qualityprofile"
+            ) as resp:
+                if resp.status != 200:
+                    return None
+                self._quality_profiles = await resp.json()
+
+        if self._quality_profiles:
+            return self._quality_profiles[0].get("id")
+        return None
+
+    async def _get_default_root_folder(self) -> str | None:
+        """Return the first root folder path, caching after first call."""
+        if self._root_folders is None:
+            session = await self._get_session()
+            async with session.get(
+                f"{self.base_url}/api/v3/rootfolder"
+            ) as resp:
+                if resp.status != 200:
+                    return None
+                self._root_folders = await resp.json()
+
+        if self._root_folders:
+            return self._root_folders[0].get("path")
+        return None
+
+    # ------------------------------------------------------------------
+    # Formatting helpers
+    # ------------------------------------------------------------------
+
+    def _format_search_results(self, results: list[dict], query: str) -> str:
+        """Format TVDB search results for LLM consumption."""
+        lines = [f"Found {len(results)} result(s) for '{query}':\n"]
+        for i, series in enumerate(results, 1):
+            title = series.get("title", "Unknown")
+            year = series.get("year", "")
+            tvdb_id = series.get("tvdbId", "?")
+            season_count = series.get("seasonCount", 0)
+            status = series.get("status", "unknown")
+            overview = series.get("overview", "")
+            # Truncate overview to keep response concise
+            if len(overview) > 100:
+                overview = overview[:100] + "..."
+
+            lines.append(
+                f"{i}. {title} ({year}) [TVDB: {tvdb_id}] - "
+                f"{season_count} season{'s' if season_count != 1 else ''}, {status}"
+            )
+            if overview:
+                lines.append(f"   {overview}")
+        return "\n".join(lines)
+
+    def _format_library_results(self, series_list: list[dict]) -> str:
+        """Format library matches for LLM consumption."""
+        lines = []
+        for series in series_list:
+            title = series.get("title", "Unknown")
+            year = series.get("year", "")
+            series_id = series.get("id", "?")
+            monitored = "Monitored" if series.get("monitored") else "Unmonitored"
+            status = series.get("status", "unknown")
+
+            stats = series.get("statistics") or {}
+            episode_file_count = stats.get("episodeFileCount", 0)
+            episode_count = stats.get("episodeCount", 0)
+            size_bytes = stats.get("sizeOnDisk") or 0
+            size_gb = size_bytes / (1024 ** 3)
+
+            lines.append(f"{title} ({year}) [ID: {series_id}]")
+            lines.append(
+                f"  Episodes: {episode_file_count}/{episode_count} downloaded"
+                f" ({size_gb:.1f} GB)"
+            )
+            lines.append(f"  Status: {status} | {monitored}")
+            lines.append("")
+
+        return "\n".join(lines).rstrip()
+
+    def _format_queue(self, records: list[dict]) -> str:
+        """Format download queue for LLM consumption."""
+        lines = [f"Active downloads ({len(records)}):\n"]
+        for item in records:
+            title = item.get("title", "Unknown")
+            status = item.get("status", "unknown")
+            size = item.get("size") or 0
+            size_left = item.get("sizeleft") or 0
+            time_left = item.get("timeleft", "unknown")
+
+            if size > 0:
+                progress_pct = ((size - size_left) / size) * 100
+            else:
+                progress_pct = 0.0
+
+            lines.append(f"- {title}")
+            lines.append(
+                f"  {status} - {progress_pct:.1f}% complete (ETA: {time_left})"
+            )
+        return "\n".join(lines)

--- a/nanobot/tools/test_sonarr.py
+++ b/nanobot/tools/test_sonarr.py
@@ -1,0 +1,459 @@
+"""Tests for Sonarr tool.
+
+Run with: pytest nanobot/tools/test_sonarr.py -v
+
+These tests use mocked responses — no real Sonarr instance required.
+"""
+
+import pytest
+import aiohttp
+from unittest.mock import AsyncMock, patch
+
+from .sonarr import SonarrTool
+
+
+# ---------------------------------------------------------------------------
+# Sample API responses for mocking
+# ---------------------------------------------------------------------------
+
+SAMPLE_SEARCH_RESULTS = [
+    {
+        "title": "Breaking Bad",
+        "year": 2008,
+        "tvdbId": 81189,
+        "seasonCount": 5,
+        "status": "ended",
+        "overview": "A high school chemistry teacher diagnosed with inoperable lung cancer turns to manufacturing methamphetamine.",
+    },
+    {
+        "title": "Breaking Bad: Original Minisodes",
+        "year": 2009,
+        "tvdbId": 103311,
+        "seasonCount": 2,
+        "status": "ended",
+        "overview": "Short webisodes set in the Breaking Bad universe.",
+    },
+]
+
+SAMPLE_SERIES_LOOKUP = [
+    {
+        "title": "Breaking Bad",
+        "year": 2008,
+        "tvdbId": 81189,
+        "seasonCount": 5,
+        "seasons": [
+            {"seasonNumber": 1, "monitored": True},
+            {"seasonNumber": 2, "monitored": True},
+            {"seasonNumber": 3, "monitored": True},
+            {"seasonNumber": 4, "monitored": True},
+            {"seasonNumber": 5, "monitored": True},
+        ],
+    },
+]
+
+SAMPLE_ADD_RESPONSE = {
+    "id": 1,
+    "title": "Breaking Bad",
+    "year": 2008,
+    "tvdbId": 81189,
+    "seasonCount": 5,
+    "path": "/tv/Breaking Bad",
+}
+
+SAMPLE_LIBRARY = [
+    {
+        "id": 1,
+        "title": "Breaking Bad",
+        "year": 2008,
+        "monitored": True,
+        "status": "ended",
+        "statistics": {
+            "episodeFileCount": 62,
+            "episodeCount": 62,
+            "totalEpisodeCount": 62,
+            "sizeOnDisk": 128849018880,  # ~120 GB
+        },
+    },
+    {
+        "id": 2,
+        "title": "The Office",
+        "year": 2005,
+        "monitored": True,
+        "status": "ended",
+        "statistics": {
+            "episodeFileCount": 100,
+            "episodeCount": 201,
+            "totalEpisodeCount": 201,
+            "sizeOnDisk": 53687091200,  # ~50 GB
+        },
+    },
+]
+
+SAMPLE_QUALITY_PROFILES = [
+    {"id": 4, "name": "HD-1080p"},
+    {"id": 6, "name": "Ultra-HD"},
+]
+
+SAMPLE_ROOT_FOLDERS = [
+    {"id": 1, "path": "/tv"},
+]
+
+SAMPLE_QUEUE = {
+    "records": [
+        {
+            "title": "Breaking Bad - S01E01 - Pilot",
+            "status": "downloading",
+            "size": 1073741824,
+            "sizeleft": 214748364,
+            "timeleft": "00:05:30",
+        },
+    ],
+}
+
+SAMPLE_QUEUE_EMPTY = {"records": []}
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def tool():
+    """Create a tool instance with test config."""
+    return SonarrTool(base_url="http://sonarr:8989", api_key="test_key_123")
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestSonarrToolProperties:
+    """Verify tool metadata."""
+
+    def test_name(self, tool):
+        assert tool.name == "sonarr"
+
+    def test_description_mentions_series(self, tool):
+        assert "series" in tool.description.lower()
+
+    def test_parameters_has_action(self, tool):
+        props = tool.parameters["properties"]
+        assert "action" in props
+        assert set(props["action"]["enum"]) == {
+            "search_series",
+            "add_series",
+            "check_library",
+            "delete_series",
+            "get_queue",
+        }
+
+    def test_required_fields(self, tool):
+        assert tool.parameters["required"] == ["action"]
+
+    def test_to_schema(self, tool):
+        schema = tool.to_schema()
+        assert schema["type"] == "function"
+        assert schema["function"]["name"] == "sonarr"
+        assert "parameters" in schema["function"]
+
+
+class TestMissingConfig:
+    """Error when Sonarr is not configured."""
+
+    @pytest.mark.asyncio
+    async def test_missing_url(self):
+        tool = SonarrTool(base_url="", api_key="key")
+        result = await tool.execute(action="search_series", title="test")
+        assert "must be configured" in result
+
+    @pytest.mark.asyncio
+    async def test_missing_api_key(self):
+        tool = SonarrTool(base_url="http://sonarr:8989", api_key="")
+        result = await tool.execute(action="search_series", title="test")
+        assert "must be configured" in result
+
+
+class TestSearchSeries:
+    """Tests for the search_series action."""
+
+    @pytest.mark.asyncio
+    async def test_search_returns_results(self, tool):
+        with patch("tools.sonarr.aiohttp.ClientSession") as mock_cls:
+            mock_resp = AsyncMock()
+            mock_resp.status = 200
+            mock_resp.json = AsyncMock(return_value=SAMPLE_SEARCH_RESULTS)
+            mock_cls.return_value.get.return_value.__aenter__.return_value = mock_resp
+
+            result = await tool.execute(action="search_series", title="Breaking Bad")
+
+            assert "Breaking Bad" in result
+            assert "2008" in result
+            assert "81189" in result
+            assert "2 result(s)" in result
+
+    @pytest.mark.asyncio
+    async def test_search_no_results(self, tool):
+        with patch("tools.sonarr.aiohttp.ClientSession") as mock_cls:
+            mock_resp = AsyncMock()
+            mock_resp.status = 200
+            mock_resp.json = AsyncMock(return_value=[])
+            mock_cls.return_value.get.return_value.__aenter__.return_value = mock_resp
+
+            result = await tool.execute(
+                action="search_series", title="Nonexistentshow123"
+            )
+
+            assert "No series found" in result
+
+    @pytest.mark.asyncio
+    async def test_search_missing_title(self, tool):
+        result = await tool.execute(action="search_series")
+        assert "title is required" in result
+
+    @pytest.mark.asyncio
+    async def test_search_invalid_api_key(self, tool):
+        with patch("tools.sonarr.aiohttp.ClientSession") as mock_cls:
+            mock_resp = AsyncMock()
+            mock_resp.status = 401
+            mock_cls.return_value.get.return_value.__aenter__.return_value = mock_resp
+
+            result = await tool.execute(action="search_series", title="Breaking Bad")
+
+            assert "Invalid" in result
+
+
+class TestAddSeries:
+    """Tests for the add_series action."""
+
+    @pytest.mark.asyncio
+    async def test_add_success(self, tool):
+        with patch("tools.sonarr.aiohttp.ClientSession") as mock_cls:
+            mock_session = mock_cls.return_value
+
+            # Sequence: lookup → qualityprofile → rootfolder → add
+            lookup_resp = AsyncMock(status=200)
+            lookup_resp.json = AsyncMock(return_value=SAMPLE_SERIES_LOOKUP)
+
+            profile_resp = AsyncMock(status=200)
+            profile_resp.json = AsyncMock(return_value=SAMPLE_QUALITY_PROFILES)
+
+            folder_resp = AsyncMock(status=200)
+            folder_resp.json = AsyncMock(return_value=SAMPLE_ROOT_FOLDERS)
+
+            add_resp = AsyncMock(status=201)
+            add_resp.json = AsyncMock(return_value=SAMPLE_ADD_RESPONSE)
+
+            mock_session.get.return_value.__aenter__.side_effect = [
+                lookup_resp,
+                profile_resp,
+                folder_resp,
+            ]
+            mock_session.post.return_value.__aenter__.return_value = add_resp
+
+            result = await tool.execute(action="add_series", tvdb_id=81189)
+
+            assert "Added" in result
+            assert "Breaking Bad" in result
+            assert "2008" in result
+            assert "5 seasons" in result
+
+    @pytest.mark.asyncio
+    async def test_add_missing_tvdb_id(self, tool):
+        result = await tool.execute(action="add_series", title="Breaking Bad")
+        assert "tvdb_id is required" in result
+
+    @pytest.mark.asyncio
+    async def test_add_already_exists(self, tool):
+        with patch("tools.sonarr.aiohttp.ClientSession") as mock_cls:
+            mock_session = mock_cls.return_value
+
+            lookup_resp = AsyncMock(status=200)
+            lookup_resp.json = AsyncMock(return_value=SAMPLE_SERIES_LOOKUP)
+
+            profile_resp = AsyncMock(status=200)
+            profile_resp.json = AsyncMock(return_value=SAMPLE_QUALITY_PROFILES)
+
+            folder_resp = AsyncMock(status=200)
+            folder_resp.json = AsyncMock(return_value=SAMPLE_ROOT_FOLDERS)
+
+            add_resp = AsyncMock(status=400)
+            add_resp.text = AsyncMock(
+                return_value='[{"errorMessage":"This series has already been added"}]'
+            )
+
+            mock_session.get.return_value.__aenter__.side_effect = [
+                lookup_resp,
+                profile_resp,
+                folder_resp,
+            ]
+            mock_session.post.return_value.__aenter__.return_value = add_resp
+
+            result = await tool.execute(action="add_series", tvdb_id=81189)
+
+            assert "already" in result.lower()
+
+
+class TestCheckLibrary:
+    """Tests for the check_library action."""
+
+    @pytest.mark.asyncio
+    async def test_check_found_complete(self, tool):
+        with patch("tools.sonarr.aiohttp.ClientSession") as mock_cls:
+            mock_resp = AsyncMock()
+            mock_resp.status = 200
+            mock_resp.json = AsyncMock(return_value=SAMPLE_LIBRARY)
+            mock_cls.return_value.get.return_value.__aenter__.return_value = mock_resp
+
+            result = await tool.execute(action="check_library", title="Breaking Bad")
+
+            assert "Breaking Bad" in result
+            assert "62/62" in result
+            assert "120.0 GB" in result
+
+    @pytest.mark.asyncio
+    async def test_check_found_partial(self, tool):
+        with patch("tools.sonarr.aiohttp.ClientSession") as mock_cls:
+            mock_resp = AsyncMock()
+            mock_resp.status = 200
+            mock_resp.json = AsyncMock(return_value=SAMPLE_LIBRARY)
+            mock_cls.return_value.get.return_value.__aenter__.return_value = mock_resp
+
+            result = await tool.execute(action="check_library", title="Office")
+
+            assert "The Office" in result
+            assert "100/201" in result
+
+    @pytest.mark.asyncio
+    async def test_check_not_in_library(self, tool):
+        with patch("tools.sonarr.aiohttp.ClientSession") as mock_cls:
+            mock_resp = AsyncMock()
+            mock_resp.status = 200
+            mock_resp.json = AsyncMock(return_value=SAMPLE_LIBRARY)
+            mock_cls.return_value.get.return_value.__aenter__.return_value = mock_resp
+
+            result = await tool.execute(action="check_library", title="Nonexistent")
+
+            assert "not found in library" in result
+
+    @pytest.mark.asyncio
+    async def test_check_missing_title(self, tool):
+        result = await tool.execute(action="check_library")
+        assert "title is required" in result
+
+
+class TestDeleteSeries:
+    """Tests for the delete_series action."""
+
+    @pytest.mark.asyncio
+    async def test_delete_success(self, tool):
+        with patch("tools.sonarr.aiohttp.ClientSession") as mock_cls:
+            mock_resp = AsyncMock()
+            mock_resp.status = 200
+            mock_cls.return_value.delete.return_value.__aenter__.return_value = (
+                mock_resp
+            )
+
+            result = await tool.execute(action="delete_series", series_id=1)
+
+            assert "Removed" in result
+
+    @pytest.mark.asyncio
+    async def test_delete_with_files(self, tool):
+        with patch("tools.sonarr.aiohttp.ClientSession") as mock_cls:
+            mock_resp = AsyncMock()
+            mock_resp.status = 200
+            mock_cls.return_value.delete.return_value.__aenter__.return_value = (
+                mock_resp
+            )
+
+            result = await tool.execute(
+                action="delete_series", series_id=1, delete_files=True
+            )
+
+            assert "deleted files from disk" in result
+
+    @pytest.mark.asyncio
+    async def test_delete_not_found(self, tool):
+        with patch("tools.sonarr.aiohttp.ClientSession") as mock_cls:
+            mock_resp = AsyncMock()
+            mock_resp.status = 404
+            mock_cls.return_value.delete.return_value.__aenter__.return_value = (
+                mock_resp
+            )
+
+            result = await tool.execute(action="delete_series", series_id=999)
+
+            assert "not found" in result
+
+    @pytest.mark.asyncio
+    async def test_delete_missing_id(self, tool):
+        result = await tool.execute(action="delete_series")
+        assert "series_id is required" in result
+
+
+class TestGetQueue:
+    """Tests for the get_queue action."""
+
+    @pytest.mark.asyncio
+    async def test_queue_with_items(self, tool):
+        with patch("tools.sonarr.aiohttp.ClientSession") as mock_cls:
+            mock_resp = AsyncMock()
+            mock_resp.status = 200
+            mock_resp.json = AsyncMock(return_value=SAMPLE_QUEUE)
+            mock_cls.return_value.get.return_value.__aenter__.return_value = mock_resp
+
+            result = await tool.execute(action="get_queue")
+
+            assert "Breaking Bad" in result
+            assert "downloading" in result
+            assert "80.0%" in result
+            assert "00:05:30" in result
+
+    @pytest.mark.asyncio
+    async def test_queue_empty(self, tool):
+        with patch("tools.sonarr.aiohttp.ClientSession") as mock_cls:
+            mock_resp = AsyncMock()
+            mock_resp.status = 200
+            mock_resp.json = AsyncMock(return_value=SAMPLE_QUEUE_EMPTY)
+            mock_cls.return_value.get.return_value.__aenter__.return_value = mock_resp
+
+            result = await tool.execute(action="get_queue")
+
+            assert "empty" in result.lower()
+
+
+class TestErrorHandling:
+    """Tests for error handling."""
+
+    @pytest.mark.asyncio
+    async def test_unknown_action(self, tool):
+        result = await tool.execute(action="explode")
+        assert "Unknown action" in result
+
+    @pytest.mark.asyncio
+    async def test_connection_error(self, tool):
+        with patch("tools.sonarr.aiohttp.ClientSession") as mock_cls:
+            mock_cls.return_value.get.return_value.__aenter__.side_effect = (
+                aiohttp.ClientError("Connection refused")
+            )
+
+            result = await tool.execute(action="search_series", title="test")
+
+            assert "Error" in result
+
+    @pytest.mark.asyncio
+    async def test_timeout_error(self, tool):
+        with patch("tools.sonarr.aiohttp.ClientSession") as mock_cls:
+            mock_cls.return_value.get.return_value.__aenter__.side_effect = (
+                TimeoutError()
+            )
+
+            result = await tool.execute(action="search_series", title="test")
+
+            assert "timed out" in result
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary
Adds SonarrTool to enable AI agent management of TV series via Sonarr's REST API. Implements 5 actions: search_series, add_series, check_library, delete_series, get_queue. Follows the same proven pattern as RadarrTool for movies. Includes 27 comprehensive tests with 100% pass rate.

## Test Plan
- [x] All 27 Sonarr tests pass
- [x] All 27 Radarr tests still pass (no regressions)
- [x] Tool correctly registers when SONARR_URL configured
- [x] Tool gracefully handles missing configuration
- [x] API key validation works