### PR TITLE
Build Gmail Tool with unified Google OAuth

### DIFF
--- a/app/src/pages/Settings.tsx
+++ b/app/src/pages/Settings.tsx
@@ -77,7 +77,7 @@ export default function Settings() {
     }
   }
 
-  const googleConnection = connections.find(c => c.provider === 'google_calendar')
+  const googleConnection = connections.find(c => c.provider === 'google')
 
   if (!profile) {
     return (
@@ -217,24 +217,24 @@ export default function Settings() {
         )}
 
         <div className="space-y-3">
-          {/* Google Calendar */}
+          {/* Google (Calendar + Gmail) */}
           <div className="flex items-center justify-between">
             <div>
-              <div className="text-sm text-butler-100">Google Calendar</div>
+              <div className="text-sm text-butler-100">Google</div>
               {connectionsLoading ? (
                 <div className="text-xs text-butler-500">Checking...</div>
               ) : googleConnection ? (
                 <div className="text-xs text-butler-400">
-                  Connected{googleConnection.accountId ? ` as ${googleConnection.accountId}` : ''}
+                  Connected{googleConnection.accountId ? ` as ${googleConnection.accountId}` : ''} &middot; Calendar, Gmail
                 </div>
               ) : (
-                <div className="text-xs text-butler-500">Not connected</div>
+                <div className="text-xs text-butler-500">Not connected &middot; Calendar, Gmail</div>
               )}
             </div>
             {!connectionsLoading && (
               googleConnection ? (
                 <button
-                  onClick={() => disconnectProvider('google_calendar')}
+                  onClick={() => disconnectProvider('google')}
                   className="px-3 py-1.5 rounded-lg text-xs bg-red-900/50 text-red-300 hover:bg-red-900 hover:text-red-200"
                 >
                   Disconnect

--- a/docs/google-oauth-setup.md
+++ b/docs/google-oauth-setup.md
@@ -1,6 +1,6 @@
 # Google OAuth Setup
 
-This guide walks you through creating Google OAuth credentials so Butler can access Google Calendar (and eventually Gmail, etc.) on behalf of household members.
+This guide walks you through creating Google OAuth credentials so Butler can access Google Calendar and Gmail on behalf of household members.
 
 **Time:** ~10 minutes, one-time setup.
 
@@ -13,11 +13,11 @@ This guide walks you through creating Google OAuth credentials so Butler can acc
 3. Name it something like `Butler Home Server`
 4. Click **Create**
 
-## 2. Enable the Google Calendar API
+## 2. Enable Google APIs
 
 1. In your new project, go to **APIs & Services > Library**
-2. Search for **Google Calendar API**
-3. Click it and press **Enable**
+2. Search for **Google Calendar API**, click it and press **Enable**
+3. Go back to the Library, search for **Gmail API**, click it and press **Enable**
 
 ## 3. Configure the OAuth Consent Screen
 
@@ -30,6 +30,7 @@ This guide walks you through creating Google OAuth credentials so Butler can acc
 4. Click **Save and Continue**
 5. On the **Scopes** page, click **Add or Remove Scopes** and add:
    - `https://www.googleapis.com/auth/calendar.readonly`
+   - `https://www.googleapis.com/auth/gmail.readonly`
    - `https://www.googleapis.com/auth/userinfo.email`
 6. Click **Save and Continue**
 7. On the **Test users** page, add the Google accounts of your household members
@@ -66,7 +67,7 @@ For production, update `GOOGLE_REDIRECT_URI` and `OAUTH_FRONTEND_URL` to your Ta
 docker compose restart butler-api
 ```
 
-Each household member can now connect their Google Calendar in **Settings > Connected Services**.
+Each household member can now connect their Google account (Calendar + Gmail) in **Settings > Connected Services**.
 
 ---
 
@@ -82,8 +83,9 @@ Your OAuth app starts in **Testing** mode. This is fine for a home server:
 
 ### Adding More Google Services
 
-The same OAuth credentials work for additional Google APIs. To add Gmail access later:
+The same OAuth credentials work for additional Google APIs. To add a new service:
 
-1. Enable the **Gmail API** in Google Cloud Console
-2. Add the Gmail scope to the consent screen
-3. Users may need to re-connect to grant the new scope
+1. Enable the API in Google Cloud Console (APIs & Services > Library)
+2. Add the required scope to the consent screen (APIs & Services > OAuth consent screen > Scopes)
+3. Add the scope to `GOOGLE_SCOPES` in `nanobot/api/oauth.py`
+4. Existing users will need to disconnect and reconnect to grant the new scope

--- a/nanobot/api/deps.py
+++ b/nanobot/api/deps.py
@@ -14,6 +14,7 @@ from fastapi import Depends, Header, HTTPException
 from tools import (
     DatabasePool,
     EmbeddingService,
+    GmailTool,
     GoogleCalendarTool,
     HomeAssistantTool,
     ListEntitiesByDomainTool,
@@ -147,4 +148,5 @@ def get_user_tools(
     user_tools = dict(global_tools)
     if settings.google_client_id:
         user_tools["google_calendar"] = GoogleCalendarTool(db_pool, user_id)
+        user_tools["gmail"] = GmailTool(db_pool, user_id)
     return user_tools

--- a/nanobot/api/oauth.py
+++ b/nanobot/api/oauth.py
@@ -28,8 +28,9 @@ GOOGLE_USERINFO_URL = "https://www.googleapis.com/oauth2/v2/userinfo"
 
 # Scopes
 CALENDAR_READONLY_SCOPE = "https://www.googleapis.com/auth/calendar.readonly"
+GMAIL_READONLY_SCOPE = "https://www.googleapis.com/auth/gmail.readonly"
 USERINFO_EMAIL_SCOPE = "https://www.googleapis.com/auth/userinfo.email"
-GOOGLE_SCOPES = f"{CALENDAR_READONLY_SCOPE} {USERINFO_EMAIL_SCOPE}"
+GOOGLE_SCOPES = f"{CALENDAR_READONLY_SCOPE} {GMAIL_READONLY_SCOPE} {USERINFO_EMAIL_SCOPE}"
 
 # State JWT settings
 _STATE_TTL_MINUTES = 10

--- a/nanobot/api/routes/oauth.py
+++ b/nanobot/api/routes/oauth.py
@@ -101,7 +101,7 @@ async def google_callback(
     email = await get_google_user_email(token_data["access_token"])
 
     # Store tokens
-    await store_tokens(pool, user_id, "google_calendar", token_data, account_id=email)
+    await store_tokens(pool, user_id, "google", token_data, account_id=email)
 
     params = urlencode({"oauth": "google", "status": "success"})
     return _redirect_html(f"{frontend_url}/settings?{params}")

--- a/nanobot/migrations/002_oauth_tokens.sql
+++ b/nanobot/migrations/002_oauth_tokens.sql
@@ -7,7 +7,7 @@
 CREATE TABLE IF NOT EXISTS butler.oauth_tokens (
     id SERIAL PRIMARY KEY,
     user_id TEXT NOT NULL REFERENCES butler.users(id) ON DELETE CASCADE,
-    provider TEXT NOT NULL,                  -- 'google_calendar', 'google_gmail', etc.
+    provider TEXT NOT NULL,                  -- 'google', 'microsoft', etc.
     access_token TEXT NOT NULL,
     refresh_token TEXT,                      -- NULL for providers that don't issue refresh tokens
     token_expires_at TIMESTAMPTZ,            -- When access_token expires

--- a/nanobot/tools/__init__.py
+++ b/nanobot/tools/__init__.py
@@ -29,6 +29,7 @@ from .memory import (
     VALID_SOUL_KEYS,
 )
 from .home_assistant import HomeAssistantTool, ListEntitiesByDomainTool
+from .gmail import GmailTool
 from .google_calendar import GoogleCalendarTool
 from .radarr import RadarrTool
 from .sonarr import SonarrTool
@@ -52,6 +53,8 @@ __all__ = [
     # Home Assistant
     "HomeAssistantTool",
     "ListEntitiesByDomainTool",
+    # Gmail
+    "GmailTool",
     # Google Calendar
     "GoogleCalendarTool",
     # Radarr

--- a/nanobot/tools/gmail.py
+++ b/nanobot/tools/gmail.py
@@ -1,0 +1,399 @@
+"""Gmail integration tool for Butler.
+
+Provides read-only access to a user's Gmail, enabling the agent to
+answer questions like "Do I have any emails from Amazon?" or
+"What's my latest flight confirmation?"
+
+Requires the user to have connected their Google account via OAuth
+in the Settings page. If not connected, returns a helpful message
+directing the user to connect.
+"""
+
+from __future__ import annotations
+
+import base64
+import logging
+import re
+from datetime import datetime, timezone
+from email.utils import parseaddr
+from html import unescape
+from typing import Any
+
+import aiohttp
+
+from .base import Tool
+
+logger = logging.getLogger(__name__)
+
+GMAIL_API_BASE = "https://gmail.googleapis.com/gmail/v1/users/me"
+
+
+class GmailTool(Tool):
+    """Read-only access to a user's Gmail.
+
+    This tool is user-scoped: it's created per-request with a specific
+    user_id, unlike global tools (HA, memory) which are created once
+    at startup.
+    """
+
+    def __init__(self, db_pool, user_id: str):
+        self._pool = db_pool
+        self._user_id = user_id
+
+    @property
+    def name(self) -> str:
+        return "gmail"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Search and read the user's Gmail. Can list recent emails, "
+            "search by query (sender, subject, date, label), or read a "
+            "specific email. Read-only — cannot send, delete, or modify. "
+            "Only works if the user has connected Google in Settings."
+        )
+
+    @property
+    def parameters(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "action": {
+                    "type": "string",
+                    "enum": ["list_recent", "search_emails", "read_email"],
+                    "description": (
+                        "list_recent: get the N most recent emails. "
+                        "search_emails: find emails matching a Gmail query. "
+                        "read_email: get the full content of a specific email by ID."
+                    ),
+                },
+                "query": {
+                    "type": "string",
+                    "description": (
+                        "Gmail search query for search_emails. Supports Gmail operators: "
+                        "from:, to:, subject:, after:, before:, label:, has:attachment, "
+                        "is:unread, newer_than:2d, etc."
+                    ),
+                },
+                "message_id": {
+                    "type": "string",
+                    "description": "Gmail message ID for read_email action.",
+                },
+                "max_results": {
+                    "type": "integer",
+                    "description": "Number of emails to return (default: 10, max: 20).",
+                    "minimum": 1,
+                    "maximum": 20,
+                },
+            },
+            "required": ["action"],
+        }
+
+    async def _get_token(self) -> str | None:
+        """Get a valid Google OAuth token, refreshing if needed."""
+        from api.oauth import get_valid_token
+
+        return await get_valid_token(self._pool, self._user_id, "google")
+
+    async def execute(self, **kwargs: Any) -> str:
+        action = kwargs.get("action", "list_recent")
+
+        access_token = await self._get_token()
+        if not access_token:
+            return (
+                "Google is not connected. "
+                "Please connect it in the Settings page of the Butler app."
+            )
+
+        try:
+            if action == "list_recent":
+                return await self._list_recent(access_token, kwargs)
+            elif action == "search_emails":
+                return await self._search_emails(access_token, kwargs)
+            elif action == "read_email":
+                return await self._read_email(access_token, kwargs)
+            else:
+                return f"Unknown action: {action}. Use 'list_recent', 'search_emails', or 'read_email'."
+        except aiohttp.ClientError as e:
+            return f"Error connecting to Gmail: {e}"
+        except Exception as e:
+            logger.exception("Gmail tool error")
+            return f"Error: {e}"
+
+    async def _list_recent(self, access_token: str, kwargs: dict) -> str:
+        """List the most recent emails."""
+        max_results = min(kwargs.get("max_results", 10), 20)
+        messages = await self._fetch_message_list(access_token, max_results=max_results)
+        if isinstance(messages, str):
+            return messages
+        if not messages:
+            return "No emails found."
+        return await self._format_message_list(access_token, messages)
+
+    async def _search_emails(self, access_token: str, kwargs: dict) -> str:
+        """Search emails using a Gmail query."""
+        query = kwargs.get("query", "")
+        if not query:
+            return "Please provide a search query."
+
+        max_results = min(kwargs.get("max_results", 10), 20)
+        messages = await self._fetch_message_list(
+            access_token, query=query, max_results=max_results
+        )
+        if isinstance(messages, str):
+            return messages
+        if not messages:
+            return f"No emails matching '{query}'."
+        return await self._format_message_list(access_token, messages)
+
+    async def _read_email(self, access_token: str, kwargs: dict) -> str:
+        """Read the full content of a specific email."""
+        message_id = kwargs.get("message_id", "")
+        if not message_id:
+            return "Please provide a message_id."
+
+        message = await self._fetch_message(access_token, message_id)
+        if isinstance(message, str):
+            return message
+        return self._format_full_message(message)
+
+    async def _fetch_message_list(
+        self,
+        access_token: str,
+        query: str | None = None,
+        max_results: int = 10,
+    ) -> list[dict] | str:
+        """Fetch a list of message IDs from Gmail.
+
+        Returns a list of {id, threadId} dicts, or an error string.
+        """
+        params: dict[str, str | int] = {"maxResults": max_results}
+        if query:
+            params["q"] = query
+
+        url = f"{GMAIL_API_BASE}/messages"
+        timeout = aiohttp.ClientTimeout(total=10)
+        async with aiohttp.ClientSession(timeout=timeout) as session:
+            async with session.get(
+                url,
+                params=params,
+                headers={"Authorization": f"Bearer {access_token}"},
+            ) as resp:
+                if resp.status == 401:
+                    logger.warning(
+                        "Gmail API returned 401 for user=%s — token may need re-auth",
+                        self._user_id,
+                    )
+                    return (
+                        "Google access has expired. "
+                        "Please reconnect in Settings > Connected Services."
+                    )
+                if resp.status != 200:
+                    text = await resp.text()
+                    logger.warning("Gmail API %d: %s", resp.status, text[:200])
+                    return f"Gmail API error (status {resp.status})."
+                data = await resp.json()
+                return data.get("messages", [])
+
+    async def _fetch_message(
+        self,
+        access_token: str,
+        message_id: str,
+        fmt: str = "full",
+    ) -> dict | str:
+        """Fetch a single message by ID.
+
+        Returns the message dict, or an error string.
+        """
+        url = f"{GMAIL_API_BASE}/messages/{message_id}"
+        params = {"format": fmt}
+        timeout = aiohttp.ClientTimeout(total=10)
+        async with aiohttp.ClientSession(timeout=timeout) as session:
+            async with session.get(
+                url,
+                params=params,
+                headers={"Authorization": f"Bearer {access_token}"},
+            ) as resp:
+                if resp.status == 401:
+                    return (
+                        "Google access has expired. "
+                        "Please reconnect in Settings > Connected Services."
+                    )
+                if resp.status == 404:
+                    return f"Email not found (ID: {message_id})."
+                if resp.status != 200:
+                    text = await resp.text()
+                    logger.warning("Gmail API %d: %s", resp.status, text[:200])
+                    return f"Gmail API error (status {resp.status})."
+                return await resp.json()
+
+    async def _format_message_list(
+        self, access_token: str, messages: list[dict]
+    ) -> str:
+        """Fetch metadata for each message and format as a readable list."""
+        lines: list[str] = []
+
+        # Batch-fetch metadata for all messages
+        details = []
+        for msg in messages:
+            result = await self._fetch_message(access_token, msg["id"], fmt="metadata")
+            if isinstance(result, str):
+                continue  # skip errors for individual messages
+            details.append(result)
+
+        for msg in details:
+            headers = {
+                h["name"].lower(): h["value"]
+                for h in msg.get("payload", {}).get("headers", [])
+            }
+            subject = headers.get("subject", "(No subject)")
+            from_raw = headers.get("from", "Unknown")
+            date_str = headers.get("date", "")
+            msg_id = msg.get("id", "")
+
+            # Parse sender into a clean format
+            sender_name, sender_email = parseaddr(from_raw)
+            sender = sender_name if sender_name else sender_email
+
+            # Parse date
+            date_display = _parse_email_date(date_str)
+
+            # Check for unread
+            labels = msg.get("labelIds", [])
+            unread = " [UNREAD]" if "UNREAD" in labels else ""
+
+            snippet = unescape(msg.get("snippet", ""))
+            # Truncate snippet
+            if len(snippet) > 100:
+                snippet = snippet[:100] + "..."
+
+            lines.append(
+                f"{'─' * 40}\n"
+                f"  From: {sender}\n"
+                f"  Subject: {subject}{unread}\n"
+                f"  Date: {date_display}\n"
+                f"  Preview: {snippet}\n"
+                f"  ID: {msg_id}"
+            )
+
+        if not lines:
+            return "No emails found."
+
+        return f"Found {len(lines)} email(s):\n" + "\n".join(lines)
+
+    def _format_full_message(self, message: dict) -> str:
+        """Format a full message for reading."""
+        headers = {
+            h["name"].lower(): h["value"]
+            for h in message.get("payload", {}).get("headers", [])
+        }
+
+        subject = headers.get("subject", "(No subject)")
+        from_raw = headers.get("from", "Unknown")
+        to_raw = headers.get("to", "Unknown")
+        date_str = headers.get("date", "")
+        msg_id = message.get("id", "")
+
+        sender_name, sender_email = parseaddr(from_raw)
+        sender = f"{sender_name} <{sender_email}>" if sender_name else sender_email
+
+        date_display = _parse_email_date(date_str)
+
+        body = _extract_body(message.get("payload", {}))
+
+        # Truncate very long bodies to avoid overwhelming the LLM
+        if len(body) > 3000:
+            body = body[:3000] + "\n\n... (truncated — email is very long)"
+
+        labels = message.get("labelIds", [])
+        label_str = ", ".join(labels) if labels else "None"
+
+        return (
+            f"Subject: {subject}\n"
+            f"From: {sender}\n"
+            f"To: {to_raw}\n"
+            f"Date: {date_display}\n"
+            f"Labels: {label_str}\n"
+            f"ID: {msg_id}\n"
+            f"{'─' * 40}\n"
+            f"{body}"
+        )
+
+
+def _parse_email_date(date_str: str) -> str:
+    """Parse an email Date header into a readable format."""
+    if not date_str:
+        return "Unknown date"
+    try:
+        # Email dates can have various formats; try common ones
+        # Remove timezone name in parentheses e.g., "(UTC)"
+        clean = re.sub(r"\s*\([^)]*\)\s*$", "", date_str.strip())
+        # Try RFC 2822 parsing
+        from email.utils import parsedate_to_datetime
+
+        dt = parsedate_to_datetime(clean)
+        return dt.strftime("%b %d, %Y %I:%M %p")
+    except Exception:
+        return date_str
+
+
+def _extract_body(payload: dict) -> str:
+    """Extract plain text body from a Gmail message payload.
+
+    Gmail messages can be simple (body directly in payload) or multipart
+    (body nested in parts). We prefer text/plain, falling back to a
+    stripped text/html.
+    """
+    # Simple message (no parts)
+    if "parts" not in payload:
+        body_data = payload.get("body", {}).get("data", "")
+        mime = payload.get("mimeType", "")
+        if body_data:
+            decoded = base64.urlsafe_b64decode(body_data).decode("utf-8", errors="replace")
+            if "html" in mime:
+                return _strip_html(decoded)
+            return decoded
+        return "(No body content)"
+
+    # Multipart — look for text/plain first, then text/html
+    plain_text = ""
+    html_text = ""
+
+    for part in payload["parts"]:
+        mime = part.get("mimeType", "")
+        body_data = part.get("body", {}).get("data", "")
+
+        if mime == "text/plain" and body_data:
+            plain_text = base64.urlsafe_b64decode(body_data).decode("utf-8", errors="replace")
+        elif mime == "text/html" and body_data:
+            html_text = base64.urlsafe_b64decode(body_data).decode("utf-8", errors="replace")
+        elif mime.startswith("multipart/"):
+            # Recurse into nested multipart
+            nested = _extract_body(part)
+            if nested and nested != "(No body content)":
+                return nested
+
+    if plain_text:
+        return plain_text
+    if html_text:
+        return _strip_html(html_text)
+
+    return "(No body content)"
+
+
+def _strip_html(html: str) -> str:
+    """Rough HTML-to-text conversion for email bodies."""
+    # Remove style and script blocks
+    text = re.sub(r"<style[^>]*>.*?</style>", "", html, flags=re.DOTALL | re.IGNORECASE)
+    text = re.sub(r"<script[^>]*>.*?</script>", "", text, flags=re.DOTALL | re.IGNORECASE)
+    # Replace <br> and block elements with newlines
+    text = re.sub(r"<br\s*/?>", "\n", text, flags=re.IGNORECASE)
+    text = re.sub(r"</(p|div|tr|li|h[1-6])>", "\n", text, flags=re.IGNORECASE)
+    # Strip remaining tags
+    text = re.sub(r"<[^>]+>", "", text)
+    # Decode HTML entities
+    text = unescape(text)
+    # Collapse whitespace
+    text = re.sub(r"[ \t]+", " ", text)
+    text = re.sub(r"\n{3,}", "\n\n", text)
+    return text.strip()

--- a/nanobot/tools/google_calendar.py
+++ b/nanobot/tools/google_calendar.py
@@ -93,10 +93,10 @@ class GoogleCalendarTool(Tool):
         # Import here to avoid circular imports at module level
         from api.oauth import get_valid_token
 
-        access_token = await get_valid_token(self._pool, self._user_id, "google_calendar")
+        access_token = await get_valid_token(self._pool, self._user_id, "google")
         if not access_token:
             return (
-                "Google Calendar is not connected. "
+                "Google is not connected. "
                 "Please connect it in the Settings page of the Butler app."
             )
 

--- a/nanobot/tools/test_gmail.py
+++ b/nanobot/tools/test_gmail.py
@@ -1,0 +1,486 @@
+"""Tests for Gmail tool.
+
+Run with: pytest nanobot/tools/test_gmail.py -v
+
+These tests use mocked responses — no real Gmail API or OAuth required.
+"""
+
+import base64
+import pytest
+import aiohttp
+from unittest.mock import AsyncMock, patch, MagicMock
+
+from .gmail import GmailTool, _extract_body, _strip_html, _parse_email_date
+
+
+# ---------------------------------------------------------------------------
+# Sample API responses for mocking
+# ---------------------------------------------------------------------------
+
+SAMPLE_MESSAGE_LIST = {
+    "messages": [
+        {"id": "msg_001", "threadId": "thread_001"},
+        {"id": "msg_002", "threadId": "thread_002"},
+    ],
+}
+
+SAMPLE_MESSAGE_LIST_EMPTY = {}
+
+SAMPLE_MESSAGE_METADATA = {
+    "id": "msg_001",
+    "threadId": "thread_001",
+    "labelIds": ["INBOX", "UNREAD"],
+    "snippet": "Your order has shipped and is on the way",
+    "payload": {
+        "headers": [
+            {"name": "From", "value": "Amazon <ship-confirm@amazon.co.uk>"},
+            {"name": "To", "value": "ron@example.com"},
+            {"name": "Subject", "value": "Your order has shipped!"},
+            {"name": "Date", "value": "Thu, 06 Feb 2026 10:30:00 +0000"},
+        ],
+    },
+}
+
+SAMPLE_MESSAGE_METADATA_READ = {
+    "id": "msg_002",
+    "threadId": "thread_002",
+    "labelIds": ["INBOX"],
+    "snippet": "Meeting agenda for tomorrow",
+    "payload": {
+        "headers": [
+            {"name": "From", "value": "Alice <alice@example.com>"},
+            {"name": "To", "value": "ron@example.com"},
+            {"name": "Subject", "value": "Team standup notes"},
+            {"name": "Date", "value": "Wed, 05 Feb 2026 14:00:00 +0000"},
+        ],
+    },
+}
+
+_PLAIN_BODY = base64.urlsafe_b64encode(b"Hello, your flight is confirmed for Feb 10.").decode()
+_HTML_BODY = base64.urlsafe_b64encode(
+    b"<html><body><p>Hello, your flight is <b>confirmed</b> for Feb 10.</p></body></html>"
+).decode()
+
+SAMPLE_FULL_MESSAGE_PLAIN = {
+    "id": "msg_001",
+    "threadId": "thread_001",
+    "labelIds": ["INBOX", "UNREAD"],
+    "snippet": "Hello, your flight is confirmed",
+    "payload": {
+        "mimeType": "text/plain",
+        "headers": [
+            {"name": "From", "value": "Airline <bookings@airline.com>"},
+            {"name": "To", "value": "ron@example.com"},
+            {"name": "Subject", "value": "Flight Confirmation - LHR to JFK"},
+            {"name": "Date", "value": "Thu, 06 Feb 2026 09:00:00 +0000"},
+        ],
+        "body": {"data": _PLAIN_BODY, "size": 44},
+    },
+}
+
+SAMPLE_FULL_MESSAGE_MULTIPART = {
+    "id": "msg_002",
+    "threadId": "thread_002",
+    "labelIds": ["INBOX"],
+    "snippet": "Hello, your flight is confirmed",
+    "payload": {
+        "mimeType": "multipart/alternative",
+        "headers": [
+            {"name": "From", "value": "Airline <bookings@airline.com>"},
+            {"name": "To", "value": "ron@example.com"},
+            {"name": "Subject", "value": "Flight Confirmation"},
+            {"name": "Date", "value": "Thu, 06 Feb 2026 09:00:00 +0000"},
+        ],
+        "body": {"size": 0},
+        "parts": [
+            {
+                "mimeType": "text/plain",
+                "body": {"data": _PLAIN_BODY, "size": 44},
+            },
+            {
+                "mimeType": "text/html",
+                "body": {"data": _HTML_BODY, "size": 80},
+            },
+        ],
+    },
+}
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def tool():
+    """Create a tool instance with a mock db pool and user_id."""
+    mock_pool = MagicMock()
+    return GmailTool(db_pool=mock_pool, user_id="user_123")
+
+
+def _mock_aiohttp_get(responses):
+    """Helper to mock aiohttp.ClientSession with sequential GET responses.
+
+    `responses` is a list of AsyncMock response objects. Each session.get()
+    call returns the next response in sequence.
+    """
+    mock_cls = MagicMock()
+    mock_session = MagicMock()
+    mock_cls.return_value.__aenter__ = AsyncMock(return_value=mock_session)
+    mock_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+    call_index = {"i": 0}
+
+    def get_side_effect(*args, **kwargs):
+        ctx = MagicMock()
+        resp = responses[call_index["i"]]
+        call_index["i"] += 1
+        ctx.__aenter__ = AsyncMock(return_value=resp)
+        ctx.__aexit__ = AsyncMock(return_value=False)
+        return ctx
+
+    mock_session.get = MagicMock(side_effect=get_side_effect)
+    return mock_cls
+
+
+# ---------------------------------------------------------------------------
+# Tests: Tool Properties
+# ---------------------------------------------------------------------------
+
+
+class TestGmailToolProperties:
+    """Verify tool metadata."""
+
+    def test_name(self, tool):
+        assert tool.name == "gmail"
+
+    def test_description_mentions_gmail(self, tool):
+        assert "gmail" in tool.description.lower()
+
+    def test_description_mentions_read_only(self, tool):
+        assert "read-only" in tool.description.lower()
+
+    def test_parameters_has_action(self, tool):
+        props = tool.parameters["properties"]
+        assert "action" in props
+        assert set(props["action"]["enum"]) == {
+            "list_recent",
+            "search_emails",
+            "read_email",
+        }
+
+    def test_required_fields(self, tool):
+        assert tool.parameters["required"] == ["action"]
+
+    def test_to_schema(self, tool):
+        schema = tool.to_schema()
+        assert schema["type"] == "function"
+        assert schema["function"]["name"] == "gmail"
+        assert "parameters" in schema["function"]
+
+
+# ---------------------------------------------------------------------------
+# Tests: No OAuth Connection
+# ---------------------------------------------------------------------------
+
+
+class TestNoConnection:
+    """Test behavior when Google is not connected."""
+
+    @pytest.mark.asyncio
+    async def test_not_connected(self, tool):
+        tool._get_token = AsyncMock(return_value=None)
+        result = await tool.execute(action="list_recent")
+        assert "not connected" in result.lower()
+        assert "Settings" in result
+
+
+# ---------------------------------------------------------------------------
+# Tests: list_recent
+# ---------------------------------------------------------------------------
+
+
+class TestListRecent:
+    """Tests for the list_recent action."""
+
+    @pytest.mark.asyncio
+    async def test_list_recent_returns_emails(self, tool):
+        tool._get_token = AsyncMock(return_value="fake_token")
+
+        # Mock: list returns 2 messages, then fetch metadata for each
+        list_resp = AsyncMock(status=200)
+        list_resp.json = AsyncMock(return_value=SAMPLE_MESSAGE_LIST)
+
+        meta_resp_1 = AsyncMock(status=200)
+        meta_resp_1.json = AsyncMock(return_value=SAMPLE_MESSAGE_METADATA)
+
+        meta_resp_2 = AsyncMock(status=200)
+        meta_resp_2.json = AsyncMock(return_value=SAMPLE_MESSAGE_METADATA_READ)
+
+        mock_cls = _mock_aiohttp_get([list_resp, meta_resp_1, meta_resp_2])
+
+        with patch("tools.gmail.aiohttp.ClientSession", mock_cls):
+            result = await tool.execute(action="list_recent")
+
+            assert "2 email(s)" in result
+            assert "Amazon" in result
+            assert "Your order has shipped" in result
+            assert "[UNREAD]" in result
+            assert "Alice" in result
+
+    @pytest.mark.asyncio
+    async def test_list_recent_empty(self, tool):
+        tool._get_token = AsyncMock(return_value="fake_token")
+
+        list_resp = AsyncMock(status=200)
+        list_resp.json = AsyncMock(return_value=SAMPLE_MESSAGE_LIST_EMPTY)
+
+        mock_cls = _mock_aiohttp_get([list_resp])
+
+        with patch("tools.gmail.aiohttp.ClientSession", mock_cls):
+            result = await tool.execute(action="list_recent")
+            assert "No emails found" in result
+
+    @pytest.mark.asyncio
+    async def test_list_recent_401(self, tool):
+        tool._get_token = AsyncMock(return_value="fake_token")
+
+        list_resp = AsyncMock(status=401)
+
+        mock_cls = _mock_aiohttp_get([list_resp])
+
+        with patch("tools.gmail.aiohttp.ClientSession", mock_cls):
+            result = await tool.execute(action="list_recent")
+            assert "expired" in result.lower()
+
+
+# ---------------------------------------------------------------------------
+# Tests: search_emails
+# ---------------------------------------------------------------------------
+
+
+class TestSearchEmails:
+    """Tests for the search_emails action."""
+
+    @pytest.mark.asyncio
+    async def test_search_returns_results(self, tool):
+        tool._get_token = AsyncMock(return_value="fake_token")
+
+        list_resp = AsyncMock(status=200)
+        list_resp.json = AsyncMock(return_value={
+            "messages": [{"id": "msg_001", "threadId": "thread_001"}],
+        })
+
+        meta_resp = AsyncMock(status=200)
+        meta_resp.json = AsyncMock(return_value=SAMPLE_MESSAGE_METADATA)
+
+        mock_cls = _mock_aiohttp_get([list_resp, meta_resp])
+
+        with patch("tools.gmail.aiohttp.ClientSession", mock_cls):
+            result = await tool.execute(action="search_emails", query="from:amazon")
+
+            assert "1 email(s)" in result
+            assert "Amazon" in result
+
+    @pytest.mark.asyncio
+    async def test_search_no_results(self, tool):
+        tool._get_token = AsyncMock(return_value="fake_token")
+
+        list_resp = AsyncMock(status=200)
+        list_resp.json = AsyncMock(return_value={})
+
+        mock_cls = _mock_aiohttp_get([list_resp])
+
+        with patch("tools.gmail.aiohttp.ClientSession", mock_cls):
+            result = await tool.execute(action="search_emails", query="from:nobody")
+            assert "No emails matching" in result
+
+    @pytest.mark.asyncio
+    async def test_search_missing_query(self, tool):
+        tool._get_token = AsyncMock(return_value="fake_token")
+        result = await tool.execute(action="search_emails")
+        assert "provide a search query" in result.lower()
+
+
+# ---------------------------------------------------------------------------
+# Tests: read_email
+# ---------------------------------------------------------------------------
+
+
+class TestReadEmail:
+    """Tests for the read_email action."""
+
+    @pytest.mark.asyncio
+    async def test_read_plain_text_email(self, tool):
+        tool._get_token = AsyncMock(return_value="fake_token")
+
+        msg_resp = AsyncMock(status=200)
+        msg_resp.json = AsyncMock(return_value=SAMPLE_FULL_MESSAGE_PLAIN)
+
+        mock_cls = _mock_aiohttp_get([msg_resp])
+
+        with patch("tools.gmail.aiohttp.ClientSession", mock_cls):
+            result = await tool.execute(action="read_email", message_id="msg_001")
+
+            assert "Flight Confirmation" in result
+            assert "Airline" in result
+            assert "flight is confirmed" in result
+            assert "Feb 10" in result
+
+    @pytest.mark.asyncio
+    async def test_read_multipart_email(self, tool):
+        tool._get_token = AsyncMock(return_value="fake_token")
+
+        msg_resp = AsyncMock(status=200)
+        msg_resp.json = AsyncMock(return_value=SAMPLE_FULL_MESSAGE_MULTIPART)
+
+        mock_cls = _mock_aiohttp_get([msg_resp])
+
+        with patch("tools.gmail.aiohttp.ClientSession", mock_cls):
+            result = await tool.execute(action="read_email", message_id="msg_002")
+
+            # Should prefer plain text over HTML
+            assert "flight is confirmed" in result
+            assert "<html>" not in result
+
+    @pytest.mark.asyncio
+    async def test_read_email_not_found(self, tool):
+        tool._get_token = AsyncMock(return_value="fake_token")
+
+        msg_resp = AsyncMock(status=404)
+
+        mock_cls = _mock_aiohttp_get([msg_resp])
+
+        with patch("tools.gmail.aiohttp.ClientSession", mock_cls):
+            result = await tool.execute(action="read_email", message_id="nonexistent")
+            assert "not found" in result.lower()
+
+    @pytest.mark.asyncio
+    async def test_read_missing_message_id(self, tool):
+        tool._get_token = AsyncMock(return_value="fake_token")
+        result = await tool.execute(action="read_email")
+        assert "provide a message_id" in result.lower()
+
+
+# ---------------------------------------------------------------------------
+# Tests: Body Extraction Helpers
+# ---------------------------------------------------------------------------
+
+
+class TestExtractBody:
+    """Tests for the _extract_body helper."""
+
+    def test_plain_text_body(self):
+        payload = {
+            "mimeType": "text/plain",
+            "body": {"data": base64.urlsafe_b64encode(b"Hello world").decode()},
+        }
+        assert _extract_body(payload) == "Hello world"
+
+    def test_html_body_gets_stripped(self):
+        html = "<html><body><p>Hello <b>world</b></p></body></html>"
+        payload = {
+            "mimeType": "text/html",
+            "body": {"data": base64.urlsafe_b64encode(html.encode()).decode()},
+        }
+        result = _extract_body(payload)
+        assert "Hello" in result
+        assert "world" in result
+        assert "<html>" not in result
+
+    def test_multipart_prefers_plain(self):
+        plain = base64.urlsafe_b64encode(b"Plain text version").decode()
+        html = base64.urlsafe_b64encode(b"<p>HTML version</p>").decode()
+        payload = {
+            "mimeType": "multipart/alternative",
+            "parts": [
+                {"mimeType": "text/plain", "body": {"data": plain}},
+                {"mimeType": "text/html", "body": {"data": html}},
+            ],
+        }
+        assert _extract_body(payload) == "Plain text version"
+
+    def test_multipart_falls_back_to_html(self):
+        html = base64.urlsafe_b64encode(b"<p>Only HTML</p>").decode()
+        payload = {
+            "mimeType": "multipart/alternative",
+            "parts": [
+                {"mimeType": "text/plain", "body": {}},
+                {"mimeType": "text/html", "body": {"data": html}},
+            ],
+        }
+        result = _extract_body(payload)
+        assert "Only HTML" in result
+
+    def test_empty_body(self):
+        payload = {"mimeType": "text/plain", "body": {}}
+        assert _extract_body(payload) == "(No body content)"
+
+
+class TestStripHtml:
+    """Tests for the _strip_html helper."""
+
+    def test_removes_tags(self):
+        assert _strip_html("<p>Hello</p>") == "Hello"
+
+    def test_removes_style_blocks(self):
+        html = "<style>.foo { color: red; }</style><p>Content</p>"
+        result = _strip_html(html)
+        assert "Content" in result
+        assert "color" not in result
+
+    def test_br_to_newline(self):
+        assert "\n" in _strip_html("Line1<br>Line2")
+
+
+class TestParseDateHelper:
+    """Tests for the _parse_email_date helper."""
+
+    def test_valid_rfc2822(self):
+        result = _parse_email_date("Thu, 06 Feb 2026 10:30:00 +0000")
+        assert "Feb 06, 2026" in result
+        assert "10:30 AM" in result
+
+    def test_empty_string(self):
+        assert _parse_email_date("") == "Unknown date"
+
+    def test_unparseable_falls_back_to_raw(self):
+        result = _parse_email_date("some weird date")
+        assert result == "some weird date"
+
+
+# ---------------------------------------------------------------------------
+# Tests: Error Handling
+# ---------------------------------------------------------------------------
+
+
+class TestErrorHandling:
+    """Tests for error handling."""
+
+    @pytest.mark.asyncio
+    async def test_unknown_action(self, tool):
+        tool._get_token = AsyncMock(return_value="fake_token")
+        result = await tool.execute(action="send_email")
+        assert "Unknown action" in result
+
+    @pytest.mark.asyncio
+    async def test_connection_error(self, tool):
+        tool._get_token = AsyncMock(return_value="fake_token")
+
+        mock_cls = MagicMock()
+        mock_session = MagicMock()
+        mock_cls.return_value.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        ctx = MagicMock()
+        ctx.__aenter__ = AsyncMock(side_effect=aiohttp.ClientError("Connection refused"))
+        ctx.__aexit__ = AsyncMock(return_value=False)
+        mock_session.get = MagicMock(return_value=ctx)
+
+        with patch("tools.gmail.aiohttp.ClientSession", mock_cls):
+            result = await tool.execute(action="list_recent")
+            assert "Error" in result
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

Built a read-only Gmail tool that shares a single Google OAuth token with Google Calendar. Users now connect "Google" once to grant both `calendar.readonly` and `gmail.readonly` scopes.

## Key Changes

- **New Gmail tool** (`nanobot/tools/gmail.py`) with three actions:
  - `list_recent` — get N most recent emails
  - `search_emails` — search by Gmail query (from:, subject:, after:, label:, etc.)
  - `read_email` — fetch full content of a specific email
- **Unified OAuth provider** renamed from `"google_calendar"` to `"google"` so both Calendar and Gmail share one token
- **Settings UI updated** to show unified "Google" connection with Calendar + Gmail subtitle
- **OAuth setup docs** now include Gmail API enable step and `gmail.readonly` scope
- **30 tests** with mocked Gmail API responses covering all actions, helpers, and error cases

## Test Results

All 167 tool tests pass with 0 failures — existing tools unaffected.

Closes #39