### PR TITLE
Build Jellyfin Tool (#8)

### DIFF
--- a/nanobot/.env.example
+++ b/nanobot/.env.example
@@ -120,6 +120,16 @@ SONARR_URL=http://sonarr:8989
 SONARR_API_KEY=
 
 # ===================
+# Jellyfin (optional — for media library & playback control)
+# ===================
+
+# Jellyfin server URL (container name on homeserver Docker network)
+JELLYFIN_URL=http://jellyfin:8096
+
+# API key from Jellyfin: Dashboard > API Keys
+JELLYFIN_API_KEY=
+
+# ===================
 # Cloudflare Tunnel (for Alexa → Home Assistant)
 # ===================
 

--- a/nanobot/api/config.py
+++ b/nanobot/api/config.py
@@ -42,6 +42,10 @@ class Settings(BaseSettings):
     sonarr_url: str = ""
     sonarr_api_key: str = ""
 
+    # Jellyfin (media playback)
+    jellyfin_url: str = ""
+    jellyfin_api_key: str = ""
+
     # Service-to-service auth (LiveKit Agents -> butler-api)
     internal_api_key: str = ""
 

--- a/nanobot/api/deps.py
+++ b/nanobot/api/deps.py
@@ -16,6 +16,7 @@ from tools import (
     EmbeddingService,
     GoogleCalendarTool,
     HomeAssistantTool,
+    JellyfinTool,
     ListEntitiesByDomainTool,
     RadarrTool,
     RecallFactsTool,
@@ -77,6 +78,13 @@ async def init_resources() -> None:
         _tools["sonarr"] = SonarrTool(
             base_url=settings.sonarr_url,
             api_key=settings.sonarr_api_key,
+        )
+
+    # Only register Jellyfin tool if configured
+    if settings.jellyfin_url:
+        _tools["jellyfin"] = JellyfinTool(
+            base_url=settings.jellyfin_url,
+            api_key=settings.jellyfin_api_key,
         )
 
 

--- a/nanobot/tools/__init__.py
+++ b/nanobot/tools/__init__.py
@@ -30,6 +30,7 @@ from .memory import (
 )
 from .home_assistant import HomeAssistantTool, ListEntitiesByDomainTool
 from .google_calendar import GoogleCalendarTool
+from .jellyfin import JellyfinTool
 from .radarr import RadarrTool
 from .sonarr import SonarrTool
 from .weather import WeatherTool
@@ -54,6 +55,8 @@ __all__ = [
     "ListEntitiesByDomainTool",
     # Google Calendar
     "GoogleCalendarTool",
+    # Jellyfin
+    "JellyfinTool",
     # Radarr
     "RadarrTool",
     # Sonarr

--- a/nanobot/tools/jellyfin.py
+++ b/nanobot/tools/jellyfin.py
@@ -1,0 +1,524 @@
+"""Jellyfin integration tool for Butler.
+
+This tool allows the agent to search the media library, see what's playing,
+get "continue watching" lists, and control playback on connected devices
+via Jellyfin's REST API.
+
+Usage:
+    tool = JellyfinTool(base_url="http://jellyfin:8096", api_key="abc123")
+    result = await tool.execute(action="search_library", query="Inception")
+
+    # When shutting down
+    await tool.close()
+
+API Reference:
+    https://jellyfin.org/docs/
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import aiohttp
+
+from .base import Tool
+
+# Default timeout for HTTP requests (seconds)
+DEFAULT_TIMEOUT = 10
+
+
+class JellyfinTool(Tool):
+    """Search and control media playback via Jellyfin REST API.
+
+    Supports searching the library, viewing continue-watching and recently
+    added items, listing active playback sessions, starting playback on a
+    device, and sending playstate commands (pause, unpause, stop, seek).
+
+    The tool reuses HTTP sessions for better performance and caches the
+    admin user ID to minimise API calls.
+    """
+
+    def __init__(
+        self,
+        base_url: str | None = None,
+        api_key: str | None = None,
+        timeout: int = DEFAULT_TIMEOUT,
+    ):
+        """Initialize the Jellyfin tool.
+
+        Args:
+            base_url: Jellyfin URL (e.g. http://jellyfin:8096)
+            api_key: Jellyfin API key (Dashboard > API Keys)
+            timeout: HTTP request timeout in seconds (default: 10)
+        """
+        self.base_url = (base_url or "").rstrip("/")
+        self.api_key = api_key or ""
+        self.timeout = aiohttp.ClientTimeout(total=timeout)
+        self._session: aiohttp.ClientSession | None = None
+        # Cached admin user ID (fetched once on first use)
+        self._user_id: str | None = None
+
+    async def _get_session(self) -> aiohttp.ClientSession:
+        """Get or create the HTTP session."""
+        if self._session is None or self._session.closed:
+            self._session = aiohttp.ClientSession(
+                headers={
+                    "Authorization": f'MediaBrowser Token="{self.api_key}"',
+                },
+                timeout=self.timeout,
+            )
+        return self._session
+
+    async def close(self) -> None:
+        """Close the HTTP session.
+
+        Should be called when shutting down to cleanly release connections.
+        """
+        if self._session and not self._session.closed:
+            await self._session.close()
+            self._session = None
+
+    # ------------------------------------------------------------------
+    # Tool interface
+    # ------------------------------------------------------------------
+
+    @property
+    def name(self) -> str:
+        return "jellyfin"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Search and control media on Jellyfin. Search the library for "
+            "movies, TV shows, or music. See what's currently playing, get "
+            "the continue-watching list or recently added items. Start "
+            "playback on a device or pause/stop/seek."
+        )
+
+    @property
+    def parameters(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "action": {
+                    "type": "string",
+                    "enum": [
+                        "search_library",
+                        "get_resume",
+                        "get_latest",
+                        "get_sessions",
+                        "play_media",
+                        "playstate_command",
+                    ],
+                    "description": (
+                        "search_library: Find movies/shows/music by title. "
+                        "get_resume: Continue-watching list. "
+                        "get_latest: Recently added media. "
+                        "get_sessions: Active playback sessions on all devices. "
+                        "play_media: Start an item on a session (needs session_id and item_id). "
+                        "playstate_command: Pause/Unpause/Stop/Seek on a session (needs session_id and command)."
+                    ),
+                },
+                "query": {
+                    "type": "string",
+                    "description": (
+                        "Search term. Used by search_library."
+                    ),
+                },
+                "media_type": {
+                    "type": "string",
+                    "enum": ["Movie", "Series", "Episode", "Audio", "MusicAlbum"],
+                    "description": (
+                        "Filter by media type. Optional for search_library, "
+                        "get_resume, and get_latest."
+                    ),
+                },
+                "session_id": {
+                    "type": "string",
+                    "description": (
+                        "Jellyfin session ID from get_sessions results. "
+                        "Required for play_media and playstate_command."
+                    ),
+                },
+                "item_id": {
+                    "type": "string",
+                    "description": (
+                        "Jellyfin item ID from search/resume/latest results. "
+                        "Required for play_media."
+                    ),
+                },
+                "command": {
+                    "type": "string",
+                    "enum": [
+                        "PlayPause",
+                        "Pause",
+                        "Unpause",
+                        "Stop",
+                        "NextTrack",
+                        "PreviousTrack",
+                        "Seek",
+                    ],
+                    "description": (
+                        "Playstate command. Required for playstate_command."
+                    ),
+                },
+                "seek_position_ticks": {
+                    "type": "integer",
+                    "description": (
+                        "Position in ticks (1 tick = 100 nanoseconds, "
+                        "10,000,000 ticks = 1 second). Only used with Seek command."
+                    ),
+                },
+            },
+            "required": ["action"],
+        }
+
+    async def execute(self, **kwargs: Any) -> str:
+        action = kwargs["action"]
+
+        if not self.base_url or not self.api_key:
+            return "Error: JELLYFIN_URL and JELLYFIN_API_KEY must be configured."
+
+        try:
+            if action == "search_library":
+                return await self._search_library(
+                    query=kwargs.get("query", ""),
+                    media_type=kwargs.get("media_type"),
+                )
+            elif action == "get_resume":
+                return await self._get_resume(
+                    media_type=kwargs.get("media_type"),
+                )
+            elif action == "get_latest":
+                return await self._get_latest(
+                    media_type=kwargs.get("media_type"),
+                )
+            elif action == "get_sessions":
+                return await self._get_sessions()
+            elif action == "play_media":
+                return await self._play_media(
+                    session_id=kwargs.get("session_id", ""),
+                    item_id=kwargs.get("item_id", ""),
+                )
+            elif action == "playstate_command":
+                return await self._playstate_command(
+                    session_id=kwargs.get("session_id", ""),
+                    command=kwargs.get("command", ""),
+                    seek_position_ticks=kwargs.get("seek_position_ticks"),
+                )
+            else:
+                return f"Error: Unknown action '{action}'"
+        except aiohttp.ClientError as e:
+            return f"Error connecting to Jellyfin: {e}"
+        except TimeoutError:
+            return "Error: Jellyfin request timed out"
+        except Exception as e:
+            return f"Error: {e}"
+
+    # ------------------------------------------------------------------
+    # User ID resolution (cached)
+    # ------------------------------------------------------------------
+
+    async def _get_user_id(self) -> str | None:
+        """Return the first admin user ID, caching after first call."""
+        if self._user_id is not None:
+            return self._user_id
+
+        session = await self._get_session()
+        async with session.get(f"{self.base_url}/Users") as resp:
+            if resp.status != 200:
+                return None
+            users = await resp.json()
+
+        if not users:
+            return None
+
+        # Prefer the first admin user, fall back to first user
+        for user in users:
+            policy = user.get("Policy") or {}
+            if policy.get("IsAdministrator"):
+                self._user_id = user["Id"]
+                return self._user_id
+
+        self._user_id = users[0]["Id"]
+        return self._user_id
+
+    # ------------------------------------------------------------------
+    # Actions
+    # ------------------------------------------------------------------
+
+    async def _search_library(
+        self,
+        query: str,
+        media_type: str | None = None,
+    ) -> str:
+        """Search the Jellyfin library by title."""
+        if not query:
+            return "Error: query is required for search_library"
+
+        user_id = await self._get_user_id()
+        if not user_id:
+            return "Error: Could not determine Jellyfin user."
+
+        session = await self._get_session()
+        params: dict[str, Any] = {
+            "searchTerm": query,
+            "Recursive": "true",
+            "Limit": "10",
+            "Fields": "Overview,Path",
+        }
+        if media_type:
+            params["IncludeItemTypes"] = media_type
+
+        url = f"{self.base_url}/Users/{user_id}/Items"
+        async with session.get(url, params=params) as resp:
+            if resp.status == 401:
+                return "Error: Invalid Jellyfin API key."
+            if resp.status != 200:
+                return f"Error: HTTP {resp.status}"
+
+            data = await resp.json()
+
+        items = data.get("Items", [])
+        if not items:
+            return f"No results found for '{query}'"
+
+        return self._format_items(items, f"Results for '{query}'")
+
+    async def _get_resume(self, media_type: str | None = None) -> str:
+        """Get the continue-watching list."""
+        user_id = await self._get_user_id()
+        if not user_id:
+            return "Error: Could not determine Jellyfin user."
+
+        session = await self._get_session()
+        params: dict[str, Any] = {
+            "Limit": "10",
+            "Fields": "Overview",
+        }
+        if media_type:
+            params["IncludeItemTypes"] = media_type
+
+        url = f"{self.base_url}/Users/{user_id}/Items/Resume"
+        async with session.get(url, params=params) as resp:
+            if resp.status == 401:
+                return "Error: Invalid Jellyfin API key."
+            if resp.status != 200:
+                return f"Error: HTTP {resp.status}"
+
+            data = await resp.json()
+
+        items = data.get("Items", [])
+        if not items:
+            return "Nothing in continue watching."
+
+        return self._format_items(items, "Continue Watching")
+
+    async def _get_latest(self, media_type: str | None = None) -> str:
+        """Get recently added media."""
+        user_id = await self._get_user_id()
+        if not user_id:
+            return "Error: Could not determine Jellyfin user."
+
+        session = await self._get_session()
+        params: dict[str, Any] = {
+            "Limit": "10",
+            "Fields": "Overview",
+        }
+        if media_type:
+            params["IncludeItemTypes"] = media_type
+
+        url = f"{self.base_url}/Users/{user_id}/Items/Latest"
+        async with session.get(url, params=params) as resp:
+            if resp.status == 401:
+                return "Error: Invalid Jellyfin API key."
+            if resp.status != 200:
+                return f"Error: HTTP {resp.status}"
+
+            items = await resp.json()
+
+        if not items:
+            return "No recently added media."
+
+        return self._format_items(items, "Recently Added")
+
+    async def _get_sessions(self) -> str:
+        """Get active playback sessions."""
+        session = await self._get_session()
+
+        async with session.get(f"{self.base_url}/Sessions") as resp:
+            if resp.status == 401:
+                return "Error: Invalid Jellyfin API key."
+            if resp.status != 200:
+                return f"Error: HTTP {resp.status}"
+
+            sessions = await resp.json()
+
+        if not sessions:
+            return "No active sessions."
+
+        # Filter to sessions with NowPlayingItem or at least a device name
+        active = [s for s in sessions if s.get("NowPlayingItem")]
+        idle = [s for s in sessions if not s.get("NowPlayingItem")]
+
+        return self._format_sessions(active, idle)
+
+    async def _play_media(self, session_id: str, item_id: str) -> str:
+        """Start playing an item on a session."""
+        if not session_id:
+            return "Error: session_id is required for play_media (get it from get_sessions)"
+        if not item_id:
+            return "Error: item_id is required for play_media (get it from search_library)"
+
+        session = await self._get_session()
+        url = f"{self.base_url}/Sessions/{session_id}/Playing"
+        params = {
+            "ItemIds": item_id,
+            "PlayCommand": "PlayNow",
+        }
+
+        async with session.post(url, params=params) as resp:
+            if resp.status == 204:
+                return f"Started playback on session {session_id}."
+            elif resp.status == 401:
+                return "Error: Invalid Jellyfin API key."
+            elif resp.status == 404:
+                return f"Error: Session '{session_id}' not found. Use get_sessions to find active sessions."
+            else:
+                return f"Error: HTTP {resp.status}"
+
+    async def _playstate_command(
+        self,
+        session_id: str,
+        command: str,
+        seek_position_ticks: int | None = None,
+    ) -> str:
+        """Send a playstate command to a session."""
+        if not session_id:
+            return "Error: session_id is required for playstate_command"
+        if not command:
+            return "Error: command is required for playstate_command"
+
+        valid_commands = {
+            "PlayPause", "Pause", "Unpause", "Stop",
+            "NextTrack", "PreviousTrack", "Seek",
+        }
+        if command not in valid_commands:
+            return f"Error: Invalid command '{command}'. Must be one of: {', '.join(sorted(valid_commands))}"
+
+        session = await self._get_session()
+        url = f"{self.base_url}/Sessions/{session_id}/Playing/{command}"
+        params: dict[str, Any] = {}
+        if command == "Seek" and seek_position_ticks is not None:
+            params["SeekPositionTicks"] = str(seek_position_ticks)
+
+        async with session.post(url, params=params) as resp:
+            if resp.status == 204:
+                return f"Sent '{command}' to session {session_id}."
+            elif resp.status == 401:
+                return "Error: Invalid Jellyfin API key."
+            elif resp.status == 404:
+                return f"Error: Session '{session_id}' not found."
+            else:
+                return f"Error: HTTP {resp.status}"
+
+    # ------------------------------------------------------------------
+    # Formatting helpers
+    # ------------------------------------------------------------------
+
+    def _format_items(self, items: list[dict], heading: str) -> str:
+        """Format library items for LLM consumption."""
+        lines = [f"{heading} ({len(items)} item{'s' if len(items) != 1 else ''}):\n"]
+        for i, item in enumerate(items, 1):
+            name = item.get("Name", "Unknown")
+            item_type = item.get("Type", "")
+            item_id = item.get("Id", "?")
+            year = item.get("ProductionYear", "")
+            overview = item.get("Overview", "")
+
+            # Build the main line
+            year_str = f" ({year})" if year else ""
+            type_str = f" [{item_type}]" if item_type else ""
+            lines.append(f"{i}. {name}{year_str}{type_str} [ID: {item_id}]")
+
+            # Show series info for episodes
+            series_name = item.get("SeriesName")
+            if series_name:
+                season = item.get("ParentIndexNumber", "?")
+                episode = item.get("IndexNumber", "?")
+                lines.append(f"   {series_name} S{season:02d}E{episode:02d}" if isinstance(season, int) and isinstance(episode, int) else f"   {series_name} S{season}E{episode}")
+
+            # Show playback progress if available
+            ticks = item.get("UserData", {}).get("PlaybackPositionTicks", 0)
+            if ticks and ticks > 0:
+                runtime_ticks = item.get("RunTimeTicks", 0)
+                pos_min = ticks // 600_000_000
+                if runtime_ticks:
+                    pct = (ticks / runtime_ticks) * 100
+                    lines.append(f"   Progress: {pos_min}min ({pct:.0f}%)")
+                else:
+                    lines.append(f"   Progress: {pos_min}min")
+
+            # Truncate overview
+            if overview and len(overview) > 100:
+                overview = overview[:100] + "..."
+            if overview:
+                lines.append(f"   {overview}")
+
+        return "\n".join(lines)
+
+    def _format_sessions(
+        self,
+        active: list[dict],
+        idle: list[dict],
+    ) -> str:
+        """Format session list for LLM consumption."""
+        lines: list[str] = []
+
+        if active:
+            lines.append(f"Now playing ({len(active)}):\n")
+            for s in active:
+                session_id = s.get("Id", "?")
+                device = s.get("DeviceName", "Unknown device")
+                client = s.get("Client", "")
+                user = s.get("UserName", "")
+
+                np = s.get("NowPlayingItem", {})
+                item_name = np.get("Name", "Unknown")
+                item_type = np.get("Type", "")
+
+                # Show series info for episodes
+                series = np.get("SeriesName")
+                if series:
+                    season = np.get("ParentIndexNumber", "?")
+                    episode = np.get("IndexNumber", "?")
+                    if isinstance(season, int) and isinstance(episode, int):
+                        item_name = f"{series} S{season:02d}E{episode:02d} - {item_name}"
+                    else:
+                        item_name = f"{series} S{season}E{episode} - {item_name}"
+
+                lines.append(f"- {item_name} [{item_type}]")
+                lines.append(f"  Device: {device} ({client}) | User: {user}")
+                lines.append(f"  Session ID: {session_id}")
+
+                # Playback state
+                play_state = s.get("PlayState", {})
+                is_paused = play_state.get("IsPaused", False)
+                position_ticks = play_state.get("PositionTicks", 0)
+                pos_min = position_ticks // 600_000_000 if position_ticks else 0
+                state = "Paused" if is_paused else "Playing"
+                lines.append(f"  State: {state} at {pos_min}min")
+                lines.append("")
+
+        if idle:
+            lines.append(f"Idle sessions ({len(idle)}):")
+            for s in idle:
+                session_id = s.get("Id", "?")
+                device = s.get("DeviceName", "Unknown device")
+                user = s.get("UserName", "")
+                lines.append(f"- {device} (User: {user}) [Session: {session_id}]")
+
+        if not active and not idle:
+            return "No active sessions."
+
+        return "\n".join(lines).rstrip()

--- a/nanobot/tools/test_jellyfin.py
+++ b/nanobot/tools/test_jellyfin.py
@@ -1,0 +1,506 @@
+"""Tests for Jellyfin tool.
+
+Run with: pytest nanobot/tools/test_jellyfin.py -v
+
+These tests use mocked responses — no real Jellyfin instance required.
+"""
+
+import pytest
+import aiohttp
+from unittest.mock import AsyncMock, patch
+
+from .jellyfin import JellyfinTool
+
+
+# ---------------------------------------------------------------------------
+# Sample API responses for mocking
+# ---------------------------------------------------------------------------
+
+SAMPLE_USERS = [
+    {
+        "Id": "user123",
+        "Name": "Admin",
+        "Policy": {"IsAdministrator": True},
+    },
+    {
+        "Id": "user456",
+        "Name": "Guest",
+        "Policy": {"IsAdministrator": False},
+    },
+]
+
+SAMPLE_SEARCH_RESULTS = {
+    "Items": [
+        {
+            "Id": "item001",
+            "Name": "Inception",
+            "Type": "Movie",
+            "ProductionYear": 2010,
+            "Overview": "A thief who steals corporate secrets through dream-sharing technology is given the task of planting an idea.",
+        },
+        {
+            "Id": "item002",
+            "Name": "Interstellar",
+            "Type": "Movie",
+            "ProductionYear": 2014,
+            "Overview": "A team of explorers travel through a wormhole in space.",
+        },
+    ],
+    "TotalRecordCount": 2,
+}
+
+SAMPLE_SEARCH_EMPTY = {"Items": [], "TotalRecordCount": 0}
+
+SAMPLE_RESUME_ITEMS = {
+    "Items": [
+        {
+            "Id": "item010",
+            "Name": "Ozark",
+            "Type": "Episode",
+            "SeriesName": "Ozark",
+            "ParentIndexNumber": 3,
+            "IndexNumber": 5,
+            "RunTimeTicks": 36000000000,  # 60 min
+            "UserData": {"PlaybackPositionTicks": 18000000000},  # 30 min
+        },
+    ],
+    "TotalRecordCount": 1,
+}
+
+SAMPLE_LATEST_ITEMS = [
+    {
+        "Id": "item020",
+        "Name": "Dune: Part Two",
+        "Type": "Movie",
+        "ProductionYear": 2024,
+        "Overview": "Follow the mythic journey of Paul Atreides.",
+    },
+]
+
+SAMPLE_SESSIONS = [
+    {
+        "Id": "sess001",
+        "DeviceName": "Living Room TV",
+        "Client": "Jellyfin Web",
+        "UserName": "Admin",
+        "NowPlayingItem": {
+            "Name": "Pilot",
+            "Type": "Episode",
+            "SeriesName": "Breaking Bad",
+            "ParentIndexNumber": 1,
+            "IndexNumber": 1,
+        },
+        "PlayState": {
+            "IsPaused": False,
+            "PositionTicks": 12000000000,  # 20 min
+        },
+    },
+    {
+        "Id": "sess002",
+        "DeviceName": "iPhone",
+        "Client": "Jellyfin Mobile",
+        "UserName": "Guest",
+    },
+]
+
+SAMPLE_SESSIONS_EMPTY = []
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def tool():
+    """Create a tool instance with test config."""
+    return JellyfinTool(base_url="http://jellyfin:8096", api_key="test_key_123")
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestJellyfinToolProperties:
+    """Verify tool metadata."""
+
+    def test_name(self, tool):
+        assert tool.name == "jellyfin"
+
+    def test_description_mentions_media(self, tool):
+        assert "media" in tool.description.lower()
+
+    def test_parameters_has_action(self, tool):
+        props = tool.parameters["properties"]
+        assert "action" in props
+        assert set(props["action"]["enum"]) == {
+            "search_library",
+            "get_resume",
+            "get_latest",
+            "get_sessions",
+            "play_media",
+            "playstate_command",
+        }
+
+    def test_required_fields(self, tool):
+        assert tool.parameters["required"] == ["action"]
+
+    def test_to_schema(self, tool):
+        schema = tool.to_schema()
+        assert schema["type"] == "function"
+        assert schema["function"]["name"] == "jellyfin"
+        assert "parameters" in schema["function"]
+
+
+class TestMissingConfig:
+    """Error when Jellyfin is not configured."""
+
+    @pytest.mark.asyncio
+    async def test_missing_url(self):
+        tool = JellyfinTool(base_url="", api_key="key")
+        result = await tool.execute(action="search_library", query="test")
+        assert "must be configured" in result
+
+    @pytest.mark.asyncio
+    async def test_missing_api_key(self):
+        tool = JellyfinTool(base_url="http://jellyfin:8096", api_key="")
+        result = await tool.execute(action="search_library", query="test")
+        assert "must be configured" in result
+
+
+class TestSearchLibrary:
+    """Tests for the search_library action."""
+
+    @pytest.mark.asyncio
+    async def test_search_returns_results(self, tool):
+        with patch("tools.jellyfin.aiohttp.ClientSession") as mock_cls:
+            mock_session = mock_cls.return_value
+
+            # Sequence: users → items
+            users_resp = AsyncMock(status=200)
+            users_resp.json = AsyncMock(return_value=SAMPLE_USERS)
+
+            items_resp = AsyncMock(status=200)
+            items_resp.json = AsyncMock(return_value=SAMPLE_SEARCH_RESULTS)
+
+            mock_session.get.return_value.__aenter__.side_effect = [
+                users_resp,
+                items_resp,
+            ]
+
+            result = await tool.execute(action="search_library", query="Inception")
+
+            assert "Inception" in result
+            assert "2010" in result
+            assert "item001" in result
+            assert "2 item" in result
+
+    @pytest.mark.asyncio
+    async def test_search_no_results(self, tool):
+        with patch("tools.jellyfin.aiohttp.ClientSession") as mock_cls:
+            mock_session = mock_cls.return_value
+
+            users_resp = AsyncMock(status=200)
+            users_resp.json = AsyncMock(return_value=SAMPLE_USERS)
+
+            items_resp = AsyncMock(status=200)
+            items_resp.json = AsyncMock(return_value=SAMPLE_SEARCH_EMPTY)
+
+            mock_session.get.return_value.__aenter__.side_effect = [
+                users_resp,
+                items_resp,
+            ]
+
+            result = await tool.execute(action="search_library", query="Nonexistent123")
+
+            assert "No results found" in result
+
+    @pytest.mark.asyncio
+    async def test_search_missing_query(self, tool):
+        result = await tool.execute(action="search_library")
+        assert "query is required" in result
+
+    @pytest.mark.asyncio
+    async def test_search_invalid_api_key(self, tool):
+        with patch("tools.jellyfin.aiohttp.ClientSession") as mock_cls:
+            mock_session = mock_cls.return_value
+
+            users_resp = AsyncMock(status=200)
+            users_resp.json = AsyncMock(return_value=SAMPLE_USERS)
+
+            items_resp = AsyncMock(status=401)
+
+            mock_session.get.return_value.__aenter__.side_effect = [
+                users_resp,
+                items_resp,
+            ]
+
+            result = await tool.execute(action="search_library", query="test")
+
+            assert "Invalid" in result
+
+
+class TestGetResume:
+    """Tests for the get_resume action."""
+
+    @pytest.mark.asyncio
+    async def test_resume_with_items(self, tool):
+        with patch("tools.jellyfin.aiohttp.ClientSession") as mock_cls:
+            mock_session = mock_cls.return_value
+
+            users_resp = AsyncMock(status=200)
+            users_resp.json = AsyncMock(return_value=SAMPLE_USERS)
+
+            resume_resp = AsyncMock(status=200)
+            resume_resp.json = AsyncMock(return_value=SAMPLE_RESUME_ITEMS)
+
+            mock_session.get.return_value.__aenter__.side_effect = [
+                users_resp,
+                resume_resp,
+            ]
+
+            result = await tool.execute(action="get_resume")
+
+            assert "Ozark" in result
+            assert "S03E05" in result
+            assert "50%" in result
+
+    @pytest.mark.asyncio
+    async def test_resume_empty(self, tool):
+        with patch("tools.jellyfin.aiohttp.ClientSession") as mock_cls:
+            mock_session = mock_cls.return_value
+
+            users_resp = AsyncMock(status=200)
+            users_resp.json = AsyncMock(return_value=SAMPLE_USERS)
+
+            resume_resp = AsyncMock(status=200)
+            resume_resp.json = AsyncMock(return_value=SAMPLE_SEARCH_EMPTY)
+
+            mock_session.get.return_value.__aenter__.side_effect = [
+                users_resp,
+                resume_resp,
+            ]
+
+            result = await tool.execute(action="get_resume")
+
+            assert "Nothing in continue watching" in result
+
+
+class TestGetLatest:
+    """Tests for the get_latest action."""
+
+    @pytest.mark.asyncio
+    async def test_latest_returns_items(self, tool):
+        with patch("tools.jellyfin.aiohttp.ClientSession") as mock_cls:
+            mock_session = mock_cls.return_value
+
+            users_resp = AsyncMock(status=200)
+            users_resp.json = AsyncMock(return_value=SAMPLE_USERS)
+
+            latest_resp = AsyncMock(status=200)
+            latest_resp.json = AsyncMock(return_value=SAMPLE_LATEST_ITEMS)
+
+            mock_session.get.return_value.__aenter__.side_effect = [
+                users_resp,
+                latest_resp,
+            ]
+
+            result = await tool.execute(action="get_latest")
+
+            assert "Dune" in result
+            assert "2024" in result
+            assert "Recently Added" in result
+
+    @pytest.mark.asyncio
+    async def test_latest_empty(self, tool):
+        with patch("tools.jellyfin.aiohttp.ClientSession") as mock_cls:
+            mock_session = mock_cls.return_value
+
+            users_resp = AsyncMock(status=200)
+            users_resp.json = AsyncMock(return_value=SAMPLE_USERS)
+
+            latest_resp = AsyncMock(status=200)
+            latest_resp.json = AsyncMock(return_value=[])
+
+            mock_session.get.return_value.__aenter__.side_effect = [
+                users_resp,
+                latest_resp,
+            ]
+
+            result = await tool.execute(action="get_latest")
+
+            assert "No recently added" in result
+
+
+class TestGetSessions:
+    """Tests for the get_sessions action."""
+
+    @pytest.mark.asyncio
+    async def test_sessions_with_playback(self, tool):
+        with patch("tools.jellyfin.aiohttp.ClientSession") as mock_cls:
+            mock_resp = AsyncMock()
+            mock_resp.status = 200
+            mock_resp.json = AsyncMock(return_value=SAMPLE_SESSIONS)
+            mock_cls.return_value.get.return_value.__aenter__.return_value = mock_resp
+
+            result = await tool.execute(action="get_sessions")
+
+            assert "Breaking Bad" in result
+            assert "S01E01" in result
+            assert "Living Room TV" in result
+            assert "sess001" in result
+            assert "Playing" in result
+            assert "iPhone" in result
+
+    @pytest.mark.asyncio
+    async def test_sessions_empty(self, tool):
+        with patch("tools.jellyfin.aiohttp.ClientSession") as mock_cls:
+            mock_resp = AsyncMock()
+            mock_resp.status = 200
+            mock_resp.json = AsyncMock(return_value=SAMPLE_SESSIONS_EMPTY)
+            mock_cls.return_value.get.return_value.__aenter__.return_value = mock_resp
+
+            result = await tool.execute(action="get_sessions")
+
+            assert "No active sessions" in result
+
+
+class TestPlayMedia:
+    """Tests for the play_media action."""
+
+    @pytest.mark.asyncio
+    async def test_play_success(self, tool):
+        with patch("tools.jellyfin.aiohttp.ClientSession") as mock_cls:
+            mock_resp = AsyncMock()
+            mock_resp.status = 204
+            mock_cls.return_value.post.return_value.__aenter__.return_value = mock_resp
+
+            result = await tool.execute(
+                action="play_media", session_id="sess001", item_id="item001"
+            )
+
+            assert "Started playback" in result
+
+    @pytest.mark.asyncio
+    async def test_play_missing_session_id(self, tool):
+        result = await tool.execute(action="play_media", item_id="item001")
+        assert "session_id is required" in result
+
+    @pytest.mark.asyncio
+    async def test_play_missing_item_id(self, tool):
+        result = await tool.execute(action="play_media", session_id="sess001")
+        assert "item_id is required" in result
+
+    @pytest.mark.asyncio
+    async def test_play_session_not_found(self, tool):
+        with patch("tools.jellyfin.aiohttp.ClientSession") as mock_cls:
+            mock_resp = AsyncMock()
+            mock_resp.status = 404
+            mock_cls.return_value.post.return_value.__aenter__.return_value = mock_resp
+
+            result = await tool.execute(
+                action="play_media", session_id="bad_id", item_id="item001"
+            )
+
+            assert "not found" in result
+
+
+class TestPlaystateCommand:
+    """Tests for the playstate_command action."""
+
+    @pytest.mark.asyncio
+    async def test_pause_success(self, tool):
+        with patch("tools.jellyfin.aiohttp.ClientSession") as mock_cls:
+            mock_resp = AsyncMock()
+            mock_resp.status = 204
+            mock_cls.return_value.post.return_value.__aenter__.return_value = mock_resp
+
+            result = await tool.execute(
+                action="playstate_command", session_id="sess001", command="Pause"
+            )
+
+            assert "Sent 'Pause'" in result
+
+    @pytest.mark.asyncio
+    async def test_seek_with_position(self, tool):
+        with patch("tools.jellyfin.aiohttp.ClientSession") as mock_cls:
+            mock_resp = AsyncMock()
+            mock_resp.status = 204
+            mock_cls.return_value.post.return_value.__aenter__.return_value = mock_resp
+
+            result = await tool.execute(
+                action="playstate_command",
+                session_id="sess001",
+                command="Seek",
+                seek_position_ticks=300000000000,
+            )
+
+            assert "Sent 'Seek'" in result
+
+    @pytest.mark.asyncio
+    async def test_missing_session_id(self, tool):
+        result = await tool.execute(action="playstate_command", command="Pause")
+        assert "session_id is required" in result
+
+    @pytest.mark.asyncio
+    async def test_missing_command(self, tool):
+        result = await tool.execute(
+            action="playstate_command", session_id="sess001"
+        )
+        assert "command is required" in result
+
+    @pytest.mark.asyncio
+    async def test_invalid_command(self, tool):
+        result = await tool.execute(
+            action="playstate_command", session_id="sess001", command="Explode"
+        )
+        assert "Invalid command" in result
+
+    @pytest.mark.asyncio
+    async def test_session_not_found(self, tool):
+        with patch("tools.jellyfin.aiohttp.ClientSession") as mock_cls:
+            mock_resp = AsyncMock()
+            mock_resp.status = 404
+            mock_cls.return_value.post.return_value.__aenter__.return_value = mock_resp
+
+            result = await tool.execute(
+                action="playstate_command", session_id="bad_id", command="Stop"
+            )
+
+            assert "not found" in result
+
+
+class TestErrorHandling:
+    """Tests for error handling."""
+
+    @pytest.mark.asyncio
+    async def test_unknown_action(self, tool):
+        result = await tool.execute(action="explode")
+        assert "Unknown action" in result
+
+    @pytest.mark.asyncio
+    async def test_connection_error(self, tool):
+        with patch("tools.jellyfin.aiohttp.ClientSession") as mock_cls:
+            mock_cls.return_value.get.return_value.__aenter__.side_effect = (
+                aiohttp.ClientError("Connection refused")
+            )
+
+            result = await tool.execute(action="get_sessions")
+
+            assert "Error" in result
+
+    @pytest.mark.asyncio
+    async def test_timeout_error(self, tool):
+        with patch("tools.jellyfin.aiohttp.ClientSession") as mock_cls:
+            mock_cls.return_value.get.return_value.__aenter__.side_effect = (
+                TimeoutError()
+            )
+
+            result = await tool.execute(action="get_sessions")
+
+            assert "timed out" in result
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary
Implements a new JellyfinTool for the Nanobot toolkit that enables searching the media library, viewing continue-watching and recently added items, listing active playback sessions, and controlling playback on connected devices.

## Changes
- 6 new actions: `search_library`, `get_resume`, `get_latest`, `get_sessions`, `play_media`, `playstate_command`
- Follows established Sonarr/Radarr tool patterns with aiohttp session management and user ID caching
- 30 unit tests covering all actions, error paths, and edge cases (all passing)
- Configuration via `JELLYFIN_URL` and `JELLYFIN_API_KEY` environment variables

## Closes
#8