### PR TITLE
Build Immich Tool for photo search (#43)

### DIFF
--- a/nanobot/.env.example
+++ b/nanobot/.env.example
@@ -100,6 +100,16 @@ GOOGLE_REDIRECT_URI=http://localhost:8000/api/oauth/google/callback
 OAUTH_FRONTEND_URL=http://localhost:5173
 
 # ===================
+# Immich (optional — for photo search, read-only)
+# ===================
+
+# Immich server URL (container name on homeserver Docker network)
+IMMICH_URL=http://immich-server:2283
+
+# API key from Immich: Profile icon > Account Settings > API Keys
+IMMICH_API_KEY=
+
+# ===================
 # Radarr (optional — for movie library management)
 # ===================
 

--- a/nanobot/api/config.py
+++ b/nanobot/api/config.py
@@ -50,6 +50,10 @@ class Settings(BaseSettings):
     jellyfin_url: str = ""
     jellyfin_api_key: str = ""
 
+    # Immich (photo search, read-only)
+    immich_url: str = ""
+    immich_api_key: str = ""
+
     # Service-to-service auth (LiveKit Agents -> butler-api)
     internal_api_key: str = ""
 

--- a/nanobot/api/deps.py
+++ b/nanobot/api/deps.py
@@ -17,6 +17,7 @@ from tools import (
     GmailTool,
     GoogleCalendarTool,
     HomeAssistantTool,
+    ImmichTool,
     JellyfinTool,
     ListEntitiesByDomainTool,
     RadarrTool,
@@ -80,6 +81,13 @@ async def init_resources() -> None:
         _tools["readarr"] = ReadarrTool(
             base_url=settings.readarr_url,
             api_key=settings.readarr_api_key,
+        )
+
+    # Only register Immich tool if configured
+    if settings.immich_url:
+        _tools["immich"] = ImmichTool(
+            base_url=settings.immich_url,
+            api_key=settings.immich_api_key,
         )
 
     # Only register Sonarr tool if configured

--- a/nanobot/tools/__init__.py
+++ b/nanobot/tools/__init__.py
@@ -35,6 +35,7 @@ from .jellyfin import JellyfinTool
 from .radarr import RadarrTool
 from .readarr import ReadarrTool
 from .sonarr import SonarrTool
+from .immich import ImmichTool
 from .weather import WeatherTool
 
 __all__ = [
@@ -67,6 +68,8 @@ __all__ = [
     "ReadarrTool",
     # Sonarr
     "SonarrTool",
+    # Immich
+    "ImmichTool",
     # Weather
     "WeatherTool",
 ]

--- a/nanobot/tools/immich.py
+++ b/nanobot/tools/immich.py
@@ -1,0 +1,418 @@
+"""Immich photo search tool for Butler (read-only).
+
+This tool allows the agent to search photos in Immich using CLIP-based
+semantic search, date ranges, location, and facial recognition.
+
+Usage:
+    The tool is automatically registered when IMMICH_URL is configured.
+    Requires IMMICH_URL and IMMICH_API_KEY in the application settings.
+
+Example:
+    tool = ImmichTool(base_url="http://immich-server:2283", api_key="abc123")
+    result = await tool.execute(action="search_photos", query="sunset at beach")
+
+    # When shutting down
+    await tool.close()
+
+API Reference:
+    https://immich.app/docs/api/
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import aiohttp
+
+from .base import Tool
+
+# Default timeout for HTTP requests (seconds)
+DEFAULT_TIMEOUT = 15
+
+# Maximum results per search
+DEFAULT_PAGE_SIZE = 10
+
+
+class ImmichTool(Tool):
+    """Search photos in Immich via REST API (read-only).
+
+    Supports CLIP-based semantic search (natural language descriptions),
+    metadata search by date range and location, and person/face lookup.
+    No upload, delete, or modify operations are exposed.
+    """
+
+    def __init__(
+        self,
+        base_url: str | None = None,
+        api_key: str | None = None,
+        timeout: int = DEFAULT_TIMEOUT,
+    ):
+        """Initialize the Immich tool.
+
+        Args:
+            base_url: Immich URL (e.g. http://immich-server:2283)
+            api_key: Immich API key (Profile > Account Settings > API Keys)
+            timeout: HTTP request timeout in seconds (default: 15)
+        """
+        self.base_url = (base_url or "").rstrip("/")
+        self.api_key = api_key or ""
+        self.timeout = aiohttp.ClientTimeout(total=timeout)
+        self._session: aiohttp.ClientSession | None = None
+
+    async def _get_session(self) -> aiohttp.ClientSession:
+        """Get or create the HTTP session."""
+        if self._session is None or self._session.closed:
+            self._session = aiohttp.ClientSession(
+                headers={"x-api-key": self.api_key},
+                timeout=self.timeout,
+            )
+        return self._session
+
+    async def close(self) -> None:
+        """Close the HTTP session.
+
+        Should be called when shutting down to cleanly release connections.
+        """
+        if self._session and not self._session.closed:
+            await self._session.close()
+            self._session = None
+
+    # ------------------------------------------------------------------
+    # Tool interface
+    # ------------------------------------------------------------------
+
+    @property
+    def name(self) -> str:
+        return "immich"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Search photos in Immich. Find photos by natural language description "
+            "(CLIP search), date range, location, or person. Use find_person first "
+            "to get a person's ID, then pass it to search_photos. Read-only — "
+            "no upload or delete operations."
+        )
+
+    @property
+    def parameters(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "action": {
+                    "type": "string",
+                    "enum": [
+                        "search_photos",
+                        "find_person",
+                    ],
+                    "description": (
+                        "search_photos: Search for photos using text description "
+                        "(CLIP/AI), date range, location, or person ID. At least "
+                        "one filter must be provided. "
+                        "find_person: Look up a person by name to get their ID "
+                        "for use in search_photos."
+                    ),
+                },
+                "query": {
+                    "type": "string",
+                    "description": (
+                        "Natural language description of what to find "
+                        '(e.g. "birthday cake", "sunset at beach", "dog playing"). '
+                        "Used by search_photos for CLIP-based AI search."
+                    ),
+                },
+                "taken_after": {
+                    "type": "string",
+                    "description": (
+                        "ISO date for start of date range "
+                        '(e.g. "2024-12-25"). Photos taken on or after this date.'
+                    ),
+                },
+                "taken_before": {
+                    "type": "string",
+                    "description": (
+                        "ISO date for end of date range "
+                        '(e.g. "2024-12-31"). Photos taken on or before this date.'
+                    ),
+                },
+                "person_ids": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": (
+                        "Person IDs to filter by (from find_person results). "
+                        "Used by search_photos to find photos of specific people."
+                    ),
+                },
+                "city": {
+                    "type": "string",
+                    "description": "Filter photos by city name.",
+                },
+                "country": {
+                    "type": "string",
+                    "description": "Filter photos by country name.",
+                },
+                "person_name": {
+                    "type": "string",
+                    "description": (
+                        "Name of the person to look up. Used by find_person."
+                    ),
+                },
+                "page": {
+                    "type": "integer",
+                    "description": (
+                        "Page number for pagination (default: 1). "
+                        "Use when there are more results to browse."
+                    ),
+                },
+            },
+            "required": ["action"],
+        }
+
+    async def execute(self, **kwargs: Any) -> str:
+        action = kwargs["action"]
+
+        if not self.base_url or not self.api_key:
+            return "Error: IMMICH_URL and IMMICH_API_KEY must be configured."
+
+        try:
+            if action == "search_photos":
+                return await self._search_photos(
+                    query=kwargs.get("query"),
+                    taken_after=kwargs.get("taken_after"),
+                    taken_before=kwargs.get("taken_before"),
+                    person_ids=kwargs.get("person_ids"),
+                    city=kwargs.get("city"),
+                    country=kwargs.get("country"),
+                    page=kwargs.get("page", 1),
+                )
+            elif action == "find_person":
+                return await self._find_person(kwargs.get("person_name", ""))
+            else:
+                return f"Error: Unknown action '{action}'"
+        except aiohttp.ClientError as e:
+            return f"Error connecting to Immich: {e}"
+        except TimeoutError:
+            return "Error: Immich request timed out"
+        except Exception as e:
+            return f"Error: {e}"
+
+    # ------------------------------------------------------------------
+    # Actions
+    # ------------------------------------------------------------------
+
+    async def _search_photos(
+        self,
+        query: str | None = None,
+        taken_after: str | None = None,
+        taken_before: str | None = None,
+        person_ids: list[str] | None = None,
+        city: str | None = None,
+        country: str | None = None,
+        page: int = 1,
+    ) -> str:
+        """Search photos using CLIP (smart) or metadata search."""
+        # Build the request body with only provided filters
+        body: dict[str, Any] = {
+            "size": DEFAULT_PAGE_SIZE,
+            "page": page,
+            "withExif": True,
+        }
+
+        if taken_after:
+            body["takenAfter"] = _normalize_date(taken_after, start=True)
+        if taken_before:
+            body["takenBefore"] = _normalize_date(taken_before, start=False)
+        if person_ids:
+            body["personIds"] = person_ids
+        if city:
+            body["city"] = city
+        if country:
+            body["country"] = country
+
+        # Use smart search (CLIP) when a text query is provided,
+        # metadata search otherwise (for date/location/person-only queries).
+        if query:
+            body["query"] = query
+            endpoint = "/api/search/smart"
+        else:
+            # Metadata search needs at least one filter
+            has_filter = any(
+                k in body
+                for k in ("takenAfter", "takenBefore", "personIds", "city", "country")
+            )
+            if not has_filter:
+                return (
+                    "Error: search_photos requires at least one filter — "
+                    "query, taken_after, taken_before, person_ids, city, or country."
+                )
+            body["withPeople"] = True
+            endpoint = "/api/search/metadata"
+
+        session = await self._get_session()
+        url = f"{self.base_url}{endpoint}"
+
+        async with session.post(url, json=body) as resp:
+            if resp.status == 401:
+                return "Error: Invalid Immich API key."
+            if resp.status != 200:
+                return f"Error: HTTP {resp.status}"
+
+            data = await resp.json()
+
+        assets = data.get("assets", {})
+        items = assets.get("items", [])
+
+        if not items:
+            return self._format_no_results(query, taken_after, taken_before)
+
+        total = assets.get("total", len(items))
+        next_page = assets.get("nextPage")
+
+        return self._format_photo_results(items, total, page, next_page)
+
+    async def _find_person(self, name: str) -> str:
+        """Search for a person by name in Immich's face recognition database."""
+        if not name:
+            return "Error: person_name is required for find_person"
+
+        session = await self._get_session()
+        url = f"{self.base_url}/api/search/person"
+
+        async with session.get(url, params={"name": name}) as resp:
+            if resp.status == 401:
+                return "Error: Invalid Immich API key."
+            if resp.status != 200:
+                return f"Error: HTTP {resp.status}"
+
+            results = await resp.json()
+
+        if not results:
+            return f"No person found matching '{name}'."
+
+        return self._format_person_results(results, name)
+
+    # ------------------------------------------------------------------
+    # Formatting helpers
+    # ------------------------------------------------------------------
+
+    def _format_photo_results(
+        self,
+        items: list[dict],
+        total: int,
+        page: int,
+        next_page: str | None,
+    ) -> str:
+        """Format photo search results for LLM consumption."""
+        lines = [f"Found {total} photo(s) (showing page {page}):\n"]
+
+        for i, asset in enumerate(items, 1):
+            asset_id = asset.get("id", "?")
+            filename = asset.get("originalFileName", "unknown")
+            asset_type = asset.get("type", "IMAGE")
+            taken_at = asset.get("localDateTime") or asset.get("fileCreatedAt", "")
+            is_favorite = asset.get("isFavorite", False)
+
+            # Date display (just the date part)
+            date_display = taken_at[:10] if taken_at else "Unknown date"
+
+            lines.append(f"{i}. {filename} ({date_display})")
+
+            # Location from EXIF
+            exif = asset.get("exifInfo") or {}
+            location_parts = []
+            if exif.get("city"):
+                location_parts.append(exif["city"])
+            if exif.get("state"):
+                location_parts.append(exif["state"])
+            if exif.get("country"):
+                location_parts.append(exif["country"])
+            if location_parts:
+                lines.append(f"   Location: {', '.join(location_parts)}")
+
+            # Camera info
+            if exif.get("make") or exif.get("model"):
+                camera = f"{exif.get('make', '')} {exif.get('model', '')}".strip()
+                lines.append(f"   Camera: {camera}")
+
+            # People in photo
+            people = asset.get("people") or []
+            if people:
+                names = [p.get("name", "Unknown") for p in people if p.get("name")]
+                if names:
+                    lines.append(f"   People: {', '.join(names)}")
+
+            # Type and favorite
+            extras = []
+            if asset_type != "IMAGE":
+                extras.append(asset_type.lower())
+            if is_favorite:
+                extras.append("favorite")
+            if extras:
+                lines.append(f"   [{', '.join(extras)}]")
+
+            # Browseable URL
+            thumbnail_url = f"{self.base_url}/api/assets/{asset_id}/thumbnail?size=preview"
+            lines.append(f"   Preview: {thumbnail_url}")
+            lines.append("")
+
+        if next_page:
+            lines.append(f"More results available — use page={page + 1} to see next page.")
+
+        return "\n".join(lines).rstrip()
+
+    def _format_person_results(self, results: list[dict], query: str) -> str:
+        """Format person search results for LLM consumption."""
+        lines = [f"Found {len(results)} person(s) matching '{query}':\n"]
+
+        for person in results:
+            person_id = person.get("id", "?")
+            name = person.get("name", "Unknown")
+            birth_date = person.get("birthDate")
+
+            line = f"- {name} [ID: {person_id}]"
+            if birth_date:
+                line += f" (born: {birth_date})"
+            lines.append(line)
+
+            # Thumbnail URL for person face
+            lines.append(
+                f"  Face thumbnail: {self.base_url}/api/people/{person_id}/thumbnail"
+            )
+
+        lines.append(
+            "\nUse the person ID in search_photos with person_ids to find their photos."
+        )
+        return "\n".join(lines)
+
+    def _format_no_results(
+        self,
+        query: str | None,
+        taken_after: str | None,
+        taken_before: str | None,
+    ) -> str:
+        """Format a helpful no-results message."""
+        parts = []
+        if query:
+            parts.append(f"query '{query}'")
+        if taken_after and taken_before:
+            parts.append(f"date range {taken_after} to {taken_before}")
+        elif taken_after:
+            parts.append(f"after {taken_after}")
+        elif taken_before:
+            parts.append(f"before {taken_before}")
+
+        filter_desc = " with ".join(parts) if parts else "the given filters"
+        return f"No photos found for {filter_desc}."
+
+
+def _normalize_date(date_str: str, *, start: bool) -> str:
+    """Ensure a date string is in ISO 8601 format with time component.
+
+    If only a date is given (YYYY-MM-DD), append start-of-day or
+    end-of-day time so the Immich API range is inclusive.
+    """
+    if "T" in date_str:
+        return date_str
+    if start:
+        return f"{date_str}T00:00:00.000Z"
+    return f"{date_str}T23:59:59.999Z"

--- a/nanobot/tools/test_immich.py
+++ b/nanobot/tools/test_immich.py
@@ -1,0 +1,497 @@
+"""Tests for Immich photo search tool.
+
+Run with: pytest nanobot/tools/test_immich.py -v
+
+These tests use mocked responses — no real Immich instance required.
+"""
+
+import pytest
+import aiohttp
+from unittest.mock import AsyncMock, patch
+
+from .immich import ImmichTool
+
+
+# ---------------------------------------------------------------------------
+# Sample API responses for mocking
+# ---------------------------------------------------------------------------
+
+SAMPLE_SMART_SEARCH_RESPONSE = {
+    "assets": {
+        "count": 2,
+        "total": 2,
+        "nextPage": None,
+        "items": [
+            {
+                "id": "asset-uuid-001",
+                "type": "IMAGE",
+                "originalFileName": "IMG_20240904_173433.jpg",
+                "localDateTime": "2024-09-04T17:34:33.000Z",
+                "fileCreatedAt": "2024-09-04T17:34:33.000Z",
+                "isFavorite": True,
+                "exifInfo": {
+                    "make": "Apple",
+                    "model": "iPhone 15 Pro",
+                    "city": "London",
+                    "state": "England",
+                    "country": "United Kingdom",
+                },
+                "people": [
+                    {"id": "person-uuid-001", "name": "Ron"},
+                ],
+            },
+            {
+                "id": "asset-uuid-002",
+                "type": "IMAGE",
+                "originalFileName": "DSC_0042.jpg",
+                "localDateTime": "2024-08-15T10:22:00.000Z",
+                "fileCreatedAt": "2024-08-15T10:22:00.000Z",
+                "isFavorite": False,
+                "exifInfo": {
+                    "make": "Sony",
+                    "model": "A7III",
+                    "city": "Tokyo",
+                    "state": None,
+                    "country": "Japan",
+                },
+                "people": [],
+            },
+        ],
+    },
+    "albums": {"count": 0, "total": 0, "items": []},
+}
+
+SAMPLE_SEARCH_EMPTY = {
+    "assets": {
+        "count": 0,
+        "total": 0,
+        "nextPage": None,
+        "items": [],
+    },
+}
+
+SAMPLE_SEARCH_WITH_NEXT_PAGE = {
+    "assets": {
+        "count": 10,
+        "total": 25,
+        "nextPage": "page-token-2",
+        "items": [
+            {
+                "id": f"asset-uuid-{i:03d}",
+                "type": "IMAGE",
+                "originalFileName": f"photo_{i}.jpg",
+                "localDateTime": f"2024-01-{i:02d}T12:00:00.000Z",
+                "isFavorite": False,
+                "exifInfo": {},
+                "people": [],
+            }
+            for i in range(1, 11)
+        ],
+    },
+}
+
+SAMPLE_PERSON_RESULTS = [
+    {
+        "id": "person-uuid-001",
+        "name": "Ron",
+        "birthDate": "1990-05-15",
+    },
+    {
+        "id": "person-uuid-002",
+        "name": "Ronaldo",
+        "birthDate": None,
+    },
+]
+
+SAMPLE_VIDEO_RESULT = {
+    "assets": {
+        "count": 1,
+        "total": 1,
+        "nextPage": None,
+        "items": [
+            {
+                "id": "asset-uuid-video",
+                "type": "VIDEO",
+                "originalFileName": "VID_20240101.mp4",
+                "localDateTime": "2024-01-01T00:00:00.000Z",
+                "isFavorite": False,
+                "exifInfo": {},
+                "people": [],
+            },
+        ],
+    },
+}
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def tool():
+    """Create a tool instance with test config."""
+    return ImmichTool(base_url="http://immich-server:2283", api_key="test_key_123")
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestImmichToolProperties:
+    """Verify tool metadata."""
+
+    def test_name(self, tool):
+        assert tool.name == "immich"
+
+    def test_description_mentions_photos(self, tool):
+        assert "photo" in tool.description.lower()
+
+    def test_description_mentions_read_only(self, tool):
+        assert "read-only" in tool.description.lower()
+
+    def test_parameters_has_action(self, tool):
+        props = tool.parameters["properties"]
+        assert "action" in props
+        assert set(props["action"]["enum"]) == {
+            "search_photos",
+            "find_person",
+        }
+
+    def test_required_fields(self, tool):
+        assert tool.parameters["required"] == ["action"]
+
+    def test_to_schema(self, tool):
+        schema = tool.to_schema()
+        assert schema["type"] == "function"
+        assert schema["function"]["name"] == "immich"
+        assert "parameters" in schema["function"]
+
+
+class TestMissingConfig:
+    """Error when Immich is not configured."""
+
+    @pytest.mark.asyncio
+    async def test_missing_url(self):
+        tool = ImmichTool(base_url="", api_key="key")
+        result = await tool.execute(action="search_photos", query="test")
+        assert "must be configured" in result
+
+    @pytest.mark.asyncio
+    async def test_missing_api_key(self):
+        tool = ImmichTool(base_url="http://immich:2283", api_key="")
+        result = await tool.execute(action="search_photos", query="test")
+        assert "must be configured" in result
+
+
+class TestSearchPhotos:
+    """Tests for the search_photos action."""
+
+    @pytest.mark.asyncio
+    async def test_smart_search_with_query(self, tool):
+        with patch("tools.immich.aiohttp.ClientSession") as mock_cls:
+            mock_resp = AsyncMock()
+            mock_resp.status = 200
+            mock_resp.json = AsyncMock(return_value=SAMPLE_SMART_SEARCH_RESPONSE)
+            mock_cls.return_value.post.return_value.__aenter__.return_value = mock_resp
+
+            result = await tool.execute(action="search_photos", query="sunset beach")
+
+            assert "2 photo(s)" in result
+            assert "IMG_20240904_173433.jpg" in result
+            assert "London" in result
+            assert "Ron" in result
+            assert "asset-uuid-001" in result
+
+    @pytest.mark.asyncio
+    async def test_metadata_search_by_date(self, tool):
+        with patch("tools.immich.aiohttp.ClientSession") as mock_cls:
+            mock_resp = AsyncMock()
+            mock_resp.status = 200
+            mock_resp.json = AsyncMock(return_value=SAMPLE_SMART_SEARCH_RESPONSE)
+            mock_cls.return_value.post.return_value.__aenter__.return_value = mock_resp
+
+            result = await tool.execute(
+                action="search_photos",
+                taken_after="2024-09-01",
+                taken_before="2024-09-30",
+            )
+
+            assert "photo(s)" in result
+
+    @pytest.mark.asyncio
+    async def test_search_with_person_ids(self, tool):
+        with patch("tools.immich.aiohttp.ClientSession") as mock_cls:
+            mock_resp = AsyncMock()
+            mock_resp.status = 200
+            mock_resp.json = AsyncMock(return_value=SAMPLE_SMART_SEARCH_RESPONSE)
+            mock_cls.return_value.post.return_value.__aenter__.return_value = mock_resp
+
+            result = await tool.execute(
+                action="search_photos",
+                person_ids=["person-uuid-001"],
+            )
+
+            assert "photo(s)" in result
+
+    @pytest.mark.asyncio
+    async def test_smart_search_with_all_filters(self, tool):
+        with patch("tools.immich.aiohttp.ClientSession") as mock_cls:
+            mock_resp = AsyncMock()
+            mock_resp.status = 200
+            mock_resp.json = AsyncMock(return_value=SAMPLE_SMART_SEARCH_RESPONSE)
+            mock_cls.return_value.post.return_value.__aenter__.return_value = mock_resp
+
+            result = await tool.execute(
+                action="search_photos",
+                query="at the park",
+                taken_after="2024-01-01",
+                taken_before="2024-12-31",
+                person_ids=["person-uuid-001"],
+                city="London",
+                country="United Kingdom",
+            )
+
+            assert "photo(s)" in result
+
+    @pytest.mark.asyncio
+    async def test_search_no_results(self, tool):
+        with patch("tools.immich.aiohttp.ClientSession") as mock_cls:
+            mock_resp = AsyncMock()
+            mock_resp.status = 200
+            mock_resp.json = AsyncMock(return_value=SAMPLE_SEARCH_EMPTY)
+            mock_cls.return_value.post.return_value.__aenter__.return_value = mock_resp
+
+            result = await tool.execute(action="search_photos", query="unicorn")
+
+            assert "No photos found" in result
+            assert "unicorn" in result
+
+    @pytest.mark.asyncio
+    async def test_search_no_filters_error(self, tool):
+        result = await tool.execute(action="search_photos")
+        assert "requires at least one filter" in result
+
+    @pytest.mark.asyncio
+    async def test_search_shows_pagination(self, tool):
+        with patch("tools.immich.aiohttp.ClientSession") as mock_cls:
+            mock_resp = AsyncMock()
+            mock_resp.status = 200
+            mock_resp.json = AsyncMock(return_value=SAMPLE_SEARCH_WITH_NEXT_PAGE)
+            mock_cls.return_value.post.return_value.__aenter__.return_value = mock_resp
+
+            result = await tool.execute(action="search_photos", query="photos")
+
+            assert "page=2" in result
+
+    @pytest.mark.asyncio
+    async def test_search_shows_video_type(self, tool):
+        with patch("tools.immich.aiohttp.ClientSession") as mock_cls:
+            mock_resp = AsyncMock()
+            mock_resp.status = 200
+            mock_resp.json = AsyncMock(return_value=SAMPLE_VIDEO_RESULT)
+            mock_cls.return_value.post.return_value.__aenter__.return_value = mock_resp
+
+            result = await tool.execute(action="search_photos", query="video")
+
+            assert "video" in result.lower()
+
+    @pytest.mark.asyncio
+    async def test_search_shows_favorite(self, tool):
+        with patch("tools.immich.aiohttp.ClientSession") as mock_cls:
+            mock_resp = AsyncMock()
+            mock_resp.status = 200
+            mock_resp.json = AsyncMock(return_value=SAMPLE_SMART_SEARCH_RESPONSE)
+            mock_cls.return_value.post.return_value.__aenter__.return_value = mock_resp
+
+            result = await tool.execute(action="search_photos", query="test")
+
+            assert "favorite" in result.lower()
+
+    @pytest.mark.asyncio
+    async def test_search_invalid_api_key(self, tool):
+        with patch("tools.immich.aiohttp.ClientSession") as mock_cls:
+            mock_resp = AsyncMock()
+            mock_resp.status = 401
+            mock_cls.return_value.post.return_value.__aenter__.return_value = mock_resp
+
+            result = await tool.execute(action="search_photos", query="test")
+
+            assert "Invalid" in result
+
+    @pytest.mark.asyncio
+    async def test_search_includes_preview_url(self, tool):
+        with patch("tools.immich.aiohttp.ClientSession") as mock_cls:
+            mock_resp = AsyncMock()
+            mock_resp.status = 200
+            mock_resp.json = AsyncMock(return_value=SAMPLE_SMART_SEARCH_RESPONSE)
+            mock_cls.return_value.post.return_value.__aenter__.return_value = mock_resp
+
+            result = await tool.execute(action="search_photos", query="test")
+
+            assert "/api/assets/asset-uuid-001/thumbnail" in result
+
+    @pytest.mark.asyncio
+    async def test_search_by_city(self, tool):
+        with patch("tools.immich.aiohttp.ClientSession") as mock_cls:
+            mock_resp = AsyncMock()
+            mock_resp.status = 200
+            mock_resp.json = AsyncMock(return_value=SAMPLE_SMART_SEARCH_RESPONSE)
+            mock_cls.return_value.post.return_value.__aenter__.return_value = mock_resp
+
+            result = await tool.execute(action="search_photos", city="London")
+
+            assert "photo(s)" in result
+
+    @pytest.mark.asyncio
+    async def test_search_by_country(self, tool):
+        with patch("tools.immich.aiohttp.ClientSession") as mock_cls:
+            mock_resp = AsyncMock()
+            mock_resp.status = 200
+            mock_resp.json = AsyncMock(return_value=SAMPLE_SMART_SEARCH_RESPONSE)
+            mock_cls.return_value.post.return_value.__aenter__.return_value = mock_resp
+
+            result = await tool.execute(action="search_photos", country="Japan")
+
+            assert "photo(s)" in result
+
+
+class TestFindPerson:
+    """Tests for the find_person action."""
+
+    @pytest.mark.asyncio
+    async def test_find_person_success(self, tool):
+        with patch("tools.immich.aiohttp.ClientSession") as mock_cls:
+            mock_resp = AsyncMock()
+            mock_resp.status = 200
+            mock_resp.json = AsyncMock(return_value=SAMPLE_PERSON_RESULTS)
+            mock_cls.return_value.get.return_value.__aenter__.return_value = mock_resp
+
+            result = await tool.execute(action="find_person", person_name="Ron")
+
+            assert "2 person(s)" in result
+            assert "Ron" in result
+            assert "person-uuid-001" in result
+            assert "1990-05-15" in result
+            assert "Ronaldo" in result
+
+    @pytest.mark.asyncio
+    async def test_find_person_not_found(self, tool):
+        with patch("tools.immich.aiohttp.ClientSession") as mock_cls:
+            mock_resp = AsyncMock()
+            mock_resp.status = 200
+            mock_resp.json = AsyncMock(return_value=[])
+            mock_cls.return_value.get.return_value.__aenter__.return_value = mock_resp
+
+            result = await tool.execute(action="find_person", person_name="Nobody")
+
+            assert "No person found" in result
+
+    @pytest.mark.asyncio
+    async def test_find_person_missing_name(self, tool):
+        result = await tool.execute(action="find_person")
+        assert "person_name is required" in result
+
+    @pytest.mark.asyncio
+    async def test_find_person_includes_thumbnail_url(self, tool):
+        with patch("tools.immich.aiohttp.ClientSession") as mock_cls:
+            mock_resp = AsyncMock()
+            mock_resp.status = 200
+            mock_resp.json = AsyncMock(return_value=SAMPLE_PERSON_RESULTS)
+            mock_cls.return_value.get.return_value.__aenter__.return_value = mock_resp
+
+            result = await tool.execute(action="find_person", person_name="Ron")
+
+            assert "/api/people/person-uuid-001/thumbnail" in result
+
+    @pytest.mark.asyncio
+    async def test_find_person_invalid_api_key(self, tool):
+        with patch("tools.immich.aiohttp.ClientSession") as mock_cls:
+            mock_resp = AsyncMock()
+            mock_resp.status = 401
+            mock_cls.return_value.get.return_value.__aenter__.return_value = mock_resp
+
+            result = await tool.execute(action="find_person", person_name="Ron")
+
+            assert "Invalid" in result
+
+
+class TestErrorHandling:
+    """Tests for error handling."""
+
+    @pytest.mark.asyncio
+    async def test_unknown_action(self, tool):
+        result = await tool.execute(action="delete_photo")
+        assert "Unknown action" in result
+
+    @pytest.mark.asyncio
+    async def test_connection_error(self, tool):
+        with patch("tools.immich.aiohttp.ClientSession") as mock_cls:
+            mock_cls.return_value.post.return_value.__aenter__.side_effect = (
+                aiohttp.ClientError("Connection refused")
+            )
+
+            result = await tool.execute(action="search_photos", query="test")
+
+            assert "Error" in result
+
+    @pytest.mark.asyncio
+    async def test_timeout_error(self, tool):
+        with patch("tools.immich.aiohttp.ClientSession") as mock_cls:
+            mock_cls.return_value.post.return_value.__aenter__.side_effect = (
+                TimeoutError()
+            )
+
+            result = await tool.execute(action="search_photos", query="test")
+
+            assert "timed out" in result
+
+
+class TestDateNormalization:
+    """Tests for date string normalization."""
+
+    @pytest.mark.asyncio
+    async def test_date_only_gets_time_appended(self, tool):
+        """Verify that bare dates get start/end-of-day times."""
+        with patch("tools.immich.aiohttp.ClientSession") as mock_cls:
+            mock_resp = AsyncMock()
+            mock_resp.status = 200
+            mock_resp.json = AsyncMock(return_value=SAMPLE_SEARCH_EMPTY)
+            mock_session = mock_cls.return_value
+            mock_session.post.return_value.__aenter__.return_value = mock_resp
+
+            await tool.execute(
+                action="search_photos",
+                taken_after="2024-12-25",
+                taken_before="2024-12-31",
+            )
+
+            # Check the body passed to post()
+            call_args = mock_session.post.call_args
+            body = call_args.kwargs.get("json") or call_args[1].get("json")
+            assert body["takenAfter"] == "2024-12-25T00:00:00.000Z"
+            assert body["takenBefore"] == "2024-12-31T23:59:59.999Z"
+
+    @pytest.mark.asyncio
+    async def test_iso_datetime_passed_through(self, tool):
+        """Verify that full ISO datetimes are not modified."""
+        with patch("tools.immich.aiohttp.ClientSession") as mock_cls:
+            mock_resp = AsyncMock()
+            mock_resp.status = 200
+            mock_resp.json = AsyncMock(return_value=SAMPLE_SEARCH_EMPTY)
+            mock_session = mock_cls.return_value
+            mock_session.post.return_value.__aenter__.return_value = mock_resp
+
+            await tool.execute(
+                action="search_photos",
+                taken_after="2024-12-25T08:00:00.000Z",
+            )
+
+            call_args = mock_session.post.call_args
+            body = call_args.kwargs.get("json") or call_args[1].get("json")
+            assert body["takenAfter"] == "2024-12-25T08:00:00.000Z"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
Closes #43

## Summary
- Add read-only `ImmichTool` for searching photos via Immich's REST API
- **`search_photos`** action: CLIP-based smart search (natural language), metadata search by date range, person IDs, city, and country — with pagination
- **`find_person`** action: look up people by name from Immich's face recognition database to get person IDs for filtered searches
- Returns photo metadata, location, camera info, people, and browseable preview thumbnail URLs
- Strictly read-only — no upload, delete, or modify operations

## Files changed
- `nanobot/tools/immich.py` — Tool implementation (2 actions, ~300 lines)
- `nanobot/tools/test_immich.py` — 31 tests with mocked API responses
- `nanobot/tools/__init__.py` — Export ImmichTool
- `nanobot/api/config.py` — Add IMMICH_URL and IMMICH_API_KEY settings
- `nanobot/api/deps.py` — Register tool conditionally when configured
- `nanobot/.env.example` — Document Immich config vars

## Test plan
- [x] All 31 new Immich tests pass
- [x] All 226 existing tests pass (no regressions)
- [ ] Manual testing with real Immich instance (after deployment)