### PR TITLE
Build WhatsApp notification tool (outbound) (#42)

### DIFF
--- a/docker/messaging-stack/docker-compose.yml
+++ b/docker/messaging-stack/docker-compose.yml
@@ -1,0 +1,31 @@
+# Messaging Stack
+# WhatsApp gateway for outbound notifications
+# Connects to: butler-api (via homeserver network)
+#
+# First run: check logs with `docker logs whatsapp-gateway` and scan QR code
+# with your WhatsApp mobile app. Session is persisted — only needed once.
+
+services:
+  whatsapp-gateway:
+    build: ./whatsapp-gateway
+    container_name: whatsapp-gateway
+    volumes:
+      - whatsapp-data:/data
+    environment:
+      - PORT=${WHATSAPP_GATEWAY_PORT:-3000}
+    networks:
+      - homeserver
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:3000/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
+    restart: unless-stopped
+
+volumes:
+  whatsapp-data:
+
+networks:
+  homeserver:
+    external: true

--- a/docker/messaging-stack/whatsapp-gateway/Dockerfile
+++ b/docker/messaging-stack/whatsapp-gateway/Dockerfile
@@ -1,0 +1,17 @@
+FROM node:20-slim
+
+# whatsapp-web.js uses Puppeteer which needs Chromium
+RUN apt-get update && \
+    apt-get install -y chromium curl --no-install-recommends && \
+    rm -rf /var/lib/apt/lists/*
+
+ENV PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium
+ENV PUPPETEER_SKIP_DOWNLOAD=true
+
+WORKDIR /app
+COPY package.json package-lock.json* ./
+RUN npm ci --production
+COPY index.js .
+
+EXPOSE 3000
+CMD ["node", "index.js"]

--- a/docker/messaging-stack/whatsapp-gateway/index.js
+++ b/docker/messaging-stack/whatsapp-gateway/index.js
@@ -1,0 +1,164 @@
+const express = require("express");
+const { Client, LocalAuth } = require("whatsapp-web.js");
+const qrcode = require("qrcode-terminal");
+
+const PORT = process.env.PORT || 3000;
+const DATA_DIR = process.env.DATA_DIR || "/data";
+const QUEUE_MAX_AGE_MS = 60 * 60 * 1000; // 1 hour
+const QUEUE_RETRY_INTERVAL_MS = 30 * 1000; // 30 seconds
+
+// --- State ---
+
+let connected = false;
+let latestQr = null;
+let clientInfo = null;
+const messageQueue = []; // { to, message, addedAt }
+
+// --- WhatsApp Client ---
+
+const client = new Client({
+  authStrategy: new LocalAuth({ dataPath: `${DATA_DIR}/.wwebjs_auth` }),
+  puppeteer: {
+    headless: true,
+    args: ["--no-sandbox", "--disable-setuid-sandbox", "--disable-gpu"],
+  },
+});
+
+client.on("qr", (qr) => {
+  latestQr = qr;
+  console.log("[whatsapp] QR code received — scan with your phone:");
+  qrcode.generate(qr, { small: true });
+});
+
+client.on("ready", () => {
+  connected = true;
+  latestQr = null;
+  clientInfo = client.info || {};
+  console.log(`[whatsapp] Connected as ${clientInfo.pushname || "unknown"}`);
+});
+
+client.on("authenticated", () => {
+  console.log("[whatsapp] Session authenticated");
+});
+
+client.on("auth_failure", (msg) => {
+  console.error("[whatsapp] Authentication failed:", msg);
+});
+
+client.on("disconnected", (reason) => {
+  connected = false;
+  clientInfo = null;
+  console.warn("[whatsapp] Disconnected:", reason);
+});
+
+client.initialize().catch((err) => {
+  console.error("[whatsapp] Failed to initialize:", err);
+});
+
+// --- Message Queue ---
+
+function formatPhoneNumber(phone) {
+  // Strip everything except digits
+  const digits = phone.replace(/\D/g, "");
+  return `${digits}@c.us`;
+}
+
+async function sendMessage(to, message) {
+  const chatId = formatPhoneNumber(to);
+  const result = await client.sendMessage(chatId, message);
+  return result.id._serialized;
+}
+
+async function processQueue() {
+  if (!connected || messageQueue.length === 0) return;
+
+  const now = Date.now();
+  // Process from front of queue
+  while (messageQueue.length > 0) {
+    const item = messageQueue[0];
+
+    // Drop messages older than max age
+    if (now - item.addedAt > QUEUE_MAX_AGE_MS) {
+      messageQueue.shift();
+      console.warn(`[queue] Dropped expired message to ${item.to}`);
+      continue;
+    }
+
+    try {
+      await sendMessage(item.to, item.message);
+      messageQueue.shift();
+      console.log(`[queue] Delivered queued message to ${item.to}`);
+    } catch (err) {
+      console.warn(`[queue] Retry failed for ${item.to}: ${err.message}`);
+      break; // Stop processing, will retry next interval
+    }
+  }
+}
+
+setInterval(processQueue, QUEUE_RETRY_INTERVAL_MS);
+
+// --- Express API ---
+
+const app = express();
+app.use(express.json());
+
+app.get("/health", (_req, res) => {
+  res.json({ status: "ok", connected, queueSize: messageQueue.length });
+});
+
+app.get("/status", (_req, res) => {
+  res.json({
+    connected,
+    info: clientInfo
+      ? { pushname: clientInfo.pushname, phone: clientInfo.wid?.user }
+      : null,
+    queueSize: messageQueue.length,
+  });
+});
+
+app.get("/qr", (_req, res) => {
+  if (connected) {
+    return res.status(404).json({ error: "Already authenticated" });
+  }
+  if (!latestQr) {
+    return res
+      .status(404)
+      .json({ error: "No QR code available yet — client is initializing" });
+  }
+  // Return QR string (caller can render however they want)
+  res.json({ qr: latestQr });
+});
+
+app.post("/send", async (req, res) => {
+  const { to, message } = req.body || {};
+
+  if (!to || !message) {
+    return res.status(400).json({ ok: false, error: "'to' and 'message' are required" });
+  }
+
+  // If disconnected, queue for later delivery
+  if (!connected) {
+    messageQueue.push({ to, message, addedAt: Date.now() });
+    console.log(`[queue] Client disconnected — queued message to ${to}`);
+    return res.json({
+      ok: true,
+      queued: true,
+      message: "Client disconnected — message queued for delivery",
+    });
+  }
+
+  try {
+    const messageId = await sendMessage(to, message);
+    console.log(`[send] Message sent to ${to} (${messageId})`);
+    res.json({ ok: true, messageId });
+  } catch (err) {
+    console.error(`[send] Failed to send to ${to}:`, err.message);
+    // Queue on failure (e.g. transient error)
+    messageQueue.push({ to, message, addedAt: Date.now() });
+    res.status(500).json({ ok: false, error: err.message, queued: true });
+  }
+});
+
+app.listen(PORT, () => {
+  console.log(`[gateway] WhatsApp gateway listening on port ${PORT}`);
+});

--- a/docker/messaging-stack/whatsapp-gateway/package.json
+++ b/docker/messaging-stack/whatsapp-gateway/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "whatsapp-gateway",
+  "version": "1.0.0",
+  "private": true,
+  "description": "REST API gateway for outbound WhatsApp notifications via whatsapp-web.js",
+  "scripts": {
+    "start": "node index.js"
+  },
+  "dependencies": {
+    "express": "^4.21.0",
+    "qrcode-terminal": "^0.12.0",
+    "whatsapp-web.js": "^1.26.0"
+  }
+}

--- a/nanobot/.env.example
+++ b/nanobot/.env.example
@@ -48,11 +48,20 @@ TELEGRAM_ALLOW_FROM=+1234567890
 # WhatsApp (optional)
 # ===================
 
-# Enable WhatsApp integration
+# Enable WhatsApp integration (for Nanobot's built-in WhatsApp support)
 WHATSAPP_ENABLED=false
 
-# WhatsApp Business API token
+# WhatsApp Business API token (for Nanobot's built-in WhatsApp support)
 WHATSAPP_TOKEN=...
+
+# ===================
+# WhatsApp Gateway (optional — for outbound notifications via Butler)
+# ===================
+
+# WhatsApp gateway URL (container name on homeserver Docker network)
+# Requires docker/messaging-stack to be running
+# First run: check logs with `docker logs whatsapp-gateway` and scan the QR code
+WHATSAPP_GATEWAY_URL=http://whatsapp-gateway:3000
 
 # ===================
 # Butler API

--- a/nanobot/api/config.py
+++ b/nanobot/api/config.py
@@ -72,6 +72,9 @@ class Settings(BaseSettings):
     google_redirect_uri: str = "http://localhost:8000/api/oauth/google/callback"
     oauth_frontend_url: str = "http://localhost:5173"
 
+    # WhatsApp Gateway (outbound notifications)
+    whatsapp_gateway_url: str = ""
+
     model_config = {"env_file": ".env", "env_file_encoding": "utf-8"}
 
 

--- a/nanobot/api/deps.py
+++ b/nanobot/api/deps.py
@@ -31,6 +31,7 @@ from tools import (
     StorageMonitorTool,
     Tool,
     WeatherTool,
+    WhatsAppTool,
 )
 
 from .auth import decode_user_jwt
@@ -105,6 +106,13 @@ async def init_resources() -> None:
         _tools["jellyfin"] = JellyfinTool(
             base_url=settings.jellyfin_url,
             api_key=settings.jellyfin_api_key,
+        )
+
+    # Only register WhatsApp tool if configured
+    if settings.whatsapp_gateway_url:
+        _tools["whatsapp"] = WhatsAppTool(
+            gateway_url=settings.whatsapp_gateway_url,
+            db_pool=_db_pool,
         )
 
     # Health & storage monitoring (always registered — degrade gracefully)

--- a/nanobot/docker-compose.yml
+++ b/nanobot/docker-compose.yml
@@ -92,6 +92,8 @@ services:
       - GOOGLE_CLIENT_SECRET=${GOOGLE_CLIENT_SECRET:-}
       - GOOGLE_REDIRECT_URI=${GOOGLE_REDIRECT_URI:-http://localhost:8000/api/oauth/google/callback}
       - OAUTH_FRONTEND_URL=${OAUTH_FRONTEND_URL:-http://localhost:5173}
+      # WhatsApp Gateway (outbound notifications)
+      - WHATSAPP_GATEWAY_URL=${WHATSAPP_GATEWAY_URL:-}
     volumes:
       - ./api:/app/api:ro
       - ./tools:/app/tools:ro

--- a/nanobot/tools/__init__.py
+++ b/nanobot/tools/__init__.py
@@ -40,6 +40,7 @@ from .weather import WeatherTool
 from .alerting import AlertStateManager, NotificationDispatcher
 from .server_health import ServerHealthTool
 from .storage_monitor import StorageMonitorTool
+from .whatsapp import WhatsAppTool
 
 __all__ = [
     # Base
@@ -82,4 +83,6 @@ __all__ = [
     "ServerHealthTool",
     # Storage monitoring
     "StorageMonitorTool",
+    # WhatsApp
+    "WhatsAppTool",
 ]

--- a/nanobot/tools/test_whatsapp.py
+++ b/nanobot/tools/test_whatsapp.py
@@ -1,0 +1,570 @@
+"""Tests for WhatsApp notification tool.
+
+Run with: pytest nanobot/tools/test_whatsapp.py -v
+
+These tests use mocked responses — no real WhatsApp gateway or database required.
+"""
+
+import json
+import time
+
+import pytest
+import aiohttp
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from .whatsapp import WhatsAppTool, MAX_MESSAGES_PER_HOUR, VALID_CATEGORIES
+
+
+# ---------------------------------------------------------------------------
+# Sample data for mocking
+# ---------------------------------------------------------------------------
+
+SAMPLE_USER_SOUL = {
+    "whatsapp_phone": "+447123456789",
+    "notification_preferences": {
+        "enabled": True,
+        "categories": ["download", "reminder", "weather", "smart_home", "calendar", "general"],
+        "quiet_hours_start": "23:00",
+        "quiet_hours_end": "07:00",
+    },
+}
+
+SAMPLE_USER_NO_PHONE = {"personality": "friendly"}
+
+SAMPLE_USER_DISABLED = {
+    "whatsapp_phone": "+447123456789",
+    "notification_preferences": {
+        "enabled": False,
+        "categories": [],
+    },
+}
+
+SAMPLE_USER_LIMITED_CATEGORIES = {
+    "whatsapp_phone": "+447123456789",
+    "notification_preferences": {
+        "enabled": True,
+        "categories": ["download"],
+    },
+}
+
+SAMPLE_SEND_SUCCESS = {"ok": True, "messageId": "true_447123456789@c.us_ABC123"}
+SAMPLE_SEND_QUEUED = {"ok": True, "queued": True, "message": "Client disconnected"}
+SAMPLE_SEND_ERROR = {"ok": False, "error": "Number not registered on WhatsApp"}
+
+SAMPLE_STATUS_CONNECTED = {
+    "connected": True,
+    "info": {"pushname": "Butler", "phone": "447123456789"},
+    "queueSize": 0,
+}
+SAMPLE_STATUS_DISCONNECTED = {"connected": False, "info": None, "queueSize": 2}
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def mock_pool():
+    """Create a mock database pool."""
+    pool = MagicMock()
+    pool.pool = AsyncMock()
+    return pool
+
+
+@pytest.fixture
+def tool(mock_pool):
+    """Create a tool instance with test config."""
+    return WhatsAppTool(
+        gateway_url="http://whatsapp-gateway:3000",
+        db_pool=mock_pool,
+    )
+
+
+def _mock_user_row(soul: dict):
+    """Create a mock database row with the given soul JSONB."""
+    row = {"soul": json.dumps(soul)}
+    return row
+
+
+# ---------------------------------------------------------------------------
+# Tests: Tool Properties
+# ---------------------------------------------------------------------------
+
+
+class TestWhatsAppToolProperties:
+    """Verify tool metadata."""
+
+    def test_name(self, tool):
+        assert tool.name == "whatsapp"
+
+    def test_description_mentions_notifications(self, tool):
+        assert "notification" in tool.description.lower()
+
+    def test_parameters_has_action(self, tool):
+        props = tool.parameters["properties"]
+        assert "action" in props
+        assert set(props["action"]["enum"]) == {"send_message", "check_status"}
+
+    def test_parameters_has_user_id(self, tool):
+        props = tool.parameters["properties"]
+        assert "user_id" in props
+
+    def test_parameters_has_message(self, tool):
+        props = tool.parameters["properties"]
+        assert "message" in props
+
+    def test_parameters_has_category(self, tool):
+        props = tool.parameters["properties"]
+        assert "category" in props
+        # All valid categories should be in the enum
+        assert set(props["category"]["enum"]) == VALID_CATEGORIES
+
+    def test_required_fields(self, tool):
+        assert tool.parameters["required"] == ["action"]
+
+    def test_to_schema(self, tool):
+        schema = tool.to_schema()
+        assert schema["type"] == "function"
+        assert schema["function"]["name"] == "whatsapp"
+        assert "parameters" in schema["function"]
+
+
+# ---------------------------------------------------------------------------
+# Tests: Missing Config
+# ---------------------------------------------------------------------------
+
+
+class TestMissingConfig:
+    """Error when gateway is not configured."""
+
+    @pytest.mark.asyncio
+    async def test_missing_gateway_url(self, mock_pool):
+        tool = WhatsAppTool(gateway_url="", db_pool=mock_pool)
+        result = await tool.execute(action="send_message", user_id="ron", message="hi")
+        assert "must be configured" in result
+
+    @pytest.mark.asyncio
+    async def test_missing_db_pool(self):
+        tool = WhatsAppTool(gateway_url="http://gateway:3000", db_pool=None)
+        result = await tool.execute(action="send_message", user_id="ron", message="hi")
+        assert "Database pool" in result
+
+
+# ---------------------------------------------------------------------------
+# Tests: Send Message
+# ---------------------------------------------------------------------------
+
+
+class TestSendMessage:
+    """Tests for the send_message action."""
+
+    @pytest.mark.asyncio
+    async def test_send_success(self, tool, mock_pool):
+        mock_pool.pool.fetchrow = AsyncMock(
+            return_value=_mock_user_row(SAMPLE_USER_SOUL)
+        )
+
+        with patch("tools.whatsapp.aiohttp.ClientSession") as mock_cls:
+            mock_resp = AsyncMock()
+            mock_resp.status = 200
+            mock_resp.json = AsyncMock(return_value=SAMPLE_SEND_SUCCESS)
+            mock_cls.return_value.post.return_value.__aenter__.return_value = mock_resp
+
+            result = await tool.execute(
+                action="send_message",
+                user_id="ron",
+                message="Dune audiobook is ready",
+                category="download",
+            )
+
+            assert "sent to ron" in result
+
+    @pytest.mark.asyncio
+    async def test_send_queued_when_disconnected(self, tool, mock_pool):
+        mock_pool.pool.fetchrow = AsyncMock(
+            return_value=_mock_user_row(SAMPLE_USER_SOUL)
+        )
+
+        with patch("tools.whatsapp.aiohttp.ClientSession") as mock_cls:
+            mock_resp = AsyncMock()
+            mock_resp.status = 200
+            mock_resp.json = AsyncMock(return_value=SAMPLE_SEND_QUEUED)
+            mock_cls.return_value.post.return_value.__aenter__.return_value = mock_resp
+
+            result = await tool.execute(
+                action="send_message",
+                user_id="ron",
+                message="Test message",
+            )
+
+            assert "queued" in result.lower()
+
+    @pytest.mark.asyncio
+    async def test_send_missing_user_id(self, tool):
+        result = await tool.execute(action="send_message", message="hi")
+        assert "user_id is required" in result
+
+    @pytest.mark.asyncio
+    async def test_send_missing_message(self, tool):
+        result = await tool.execute(action="send_message", user_id="ron")
+        assert "message is required" in result
+
+    @pytest.mark.asyncio
+    async def test_send_user_not_found(self, tool, mock_pool):
+        mock_pool.pool.fetchrow = AsyncMock(return_value=None)
+
+        result = await tool.execute(
+            action="send_message", user_id="nobody", message="hi"
+        )
+
+        assert "not found" in result
+
+    @pytest.mark.asyncio
+    async def test_send_user_no_phone(self, tool, mock_pool):
+        mock_pool.pool.fetchrow = AsyncMock(
+            return_value=_mock_user_row(SAMPLE_USER_NO_PHONE)
+        )
+
+        result = await tool.execute(
+            action="send_message", user_id="ron", message="hi"
+        )
+
+        assert "whatsapp_phone" in result.lower() or "phone" in result.lower()
+
+    @pytest.mark.asyncio
+    async def test_send_notifications_disabled(self, tool, mock_pool):
+        mock_pool.pool.fetchrow = AsyncMock(
+            return_value=_mock_user_row(SAMPLE_USER_DISABLED)
+        )
+
+        result = await tool.execute(
+            action="send_message", user_id="ron", message="hi"
+        )
+
+        assert "disabled" in result.lower()
+
+    @pytest.mark.asyncio
+    async def test_send_category_not_opted_in(self, tool, mock_pool):
+        mock_pool.pool.fetchrow = AsyncMock(
+            return_value=_mock_user_row(SAMPLE_USER_LIMITED_CATEGORIES)
+        )
+
+        result = await tool.execute(
+            action="send_message",
+            user_id="ron",
+            message="Rain tomorrow",
+            category="weather",
+        )
+
+        assert "not opted in" in result
+
+    @pytest.mark.asyncio
+    async def test_send_defaults_to_general_category(self, tool, mock_pool):
+        mock_pool.pool.fetchrow = AsyncMock(
+            return_value=_mock_user_row(SAMPLE_USER_SOUL)
+        )
+
+        with patch("tools.whatsapp.aiohttp.ClientSession") as mock_cls:
+            mock_resp = AsyncMock()
+            mock_resp.status = 200
+            mock_resp.json = AsyncMock(return_value=SAMPLE_SEND_SUCCESS)
+            mock_cls.return_value.post.return_value.__aenter__.return_value = mock_resp
+
+            result = await tool.execute(
+                action="send_message",
+                user_id="ron",
+                message="Hello!",
+                # No category specified — should default to "general"
+            )
+
+            assert "sent to ron" in result
+
+    @pytest.mark.asyncio
+    async def test_send_gateway_error(self, tool, mock_pool):
+        mock_pool.pool.fetchrow = AsyncMock(
+            return_value=_mock_user_row(SAMPLE_USER_SOUL)
+        )
+
+        with patch("tools.whatsapp.aiohttp.ClientSession") as mock_cls:
+            mock_resp = AsyncMock()
+            mock_resp.status = 500
+            mock_resp.json = AsyncMock(return_value=SAMPLE_SEND_ERROR)
+            mock_cls.return_value.post.return_value.__aenter__.return_value = mock_resp
+
+            result = await tool.execute(
+                action="send_message",
+                user_id="ron",
+                message="Test",
+                category="download",
+            )
+
+            assert "Error" in result
+
+    @pytest.mark.asyncio
+    async def test_send_quiet_hours_blocks(self, tool, mock_pool):
+        """Quiet hours should block the message."""
+        soul_in_quiet = {
+            "whatsapp_phone": "+447123456789",
+            "notification_preferences": {
+                "enabled": True,
+                "categories": ["general"],
+                "quiet_hours_start": "00:00",
+                "quiet_hours_end": "23:59",  # All day quiet
+            },
+        }
+        mock_pool.pool.fetchrow = AsyncMock(
+            return_value=_mock_user_row(soul_in_quiet)
+        )
+
+        result = await tool.execute(
+            action="send_message", user_id="ron", message="Test"
+        )
+
+        assert "quiet hours" in result.lower()
+
+    @pytest.mark.asyncio
+    async def test_send_soul_as_dict(self, tool, mock_pool):
+        """Handle soul field already parsed as dict (not JSON string)."""
+        row = {"soul": SAMPLE_USER_SOUL}  # Already a dict, not a string
+        mock_pool.pool.fetchrow = AsyncMock(return_value=row)
+
+        with patch("tools.whatsapp.aiohttp.ClientSession") as mock_cls:
+            mock_resp = AsyncMock()
+            mock_resp.status = 200
+            mock_resp.json = AsyncMock(return_value=SAMPLE_SEND_SUCCESS)
+            mock_cls.return_value.post.return_value.__aenter__.return_value = mock_resp
+
+            result = await tool.execute(
+                action="send_message",
+                user_id="ron",
+                message="Test",
+                category="download",
+            )
+
+            assert "sent to ron" in result
+
+
+# ---------------------------------------------------------------------------
+# Tests: Check Status
+# ---------------------------------------------------------------------------
+
+
+class TestCheckStatus:
+    """Tests for the check_status action."""
+
+    @pytest.mark.asyncio
+    async def test_status_connected(self, tool):
+        with patch("tools.whatsapp.aiohttp.ClientSession") as mock_cls:
+            mock_resp = AsyncMock()
+            mock_resp.status = 200
+            mock_resp.json = AsyncMock(return_value=SAMPLE_STATUS_CONNECTED)
+            mock_cls.return_value.get.return_value.__aenter__.return_value = mock_resp
+
+            result = await tool.execute(action="check_status")
+
+            assert "connected" in result.lower()
+            assert "Butler" in result
+            assert "ready" in result
+
+    @pytest.mark.asyncio
+    async def test_status_disconnected(self, tool):
+        with patch("tools.whatsapp.aiohttp.ClientSession") as mock_cls:
+            mock_resp = AsyncMock()
+            mock_resp.status = 200
+            mock_resp.json = AsyncMock(return_value=SAMPLE_STATUS_DISCONNECTED)
+            mock_cls.return_value.get.return_value.__aenter__.return_value = mock_resp
+
+            result = await tool.execute(action="check_status")
+
+            assert "not connected" in result
+            assert "QR" in result
+
+    @pytest.mark.asyncio
+    async def test_status_gateway_down(self, tool):
+        with patch("tools.whatsapp.aiohttp.ClientSession") as mock_cls:
+            mock_resp = AsyncMock()
+            mock_resp.status = 500
+            mock_cls.return_value.get.return_value.__aenter__.return_value = mock_resp
+
+            result = await tool.execute(action="check_status")
+
+            assert "not responding" in result
+
+
+# ---------------------------------------------------------------------------
+# Tests: Error Handling
+# ---------------------------------------------------------------------------
+
+
+class TestErrorHandling:
+    """Tests for error handling."""
+
+    @pytest.mark.asyncio
+    async def test_unknown_action(self, tool):
+        result = await tool.execute(action="explode")
+        assert "Unknown action" in result
+
+    @pytest.mark.asyncio
+    async def test_connection_error(self, tool, mock_pool):
+        mock_pool.pool.fetchrow = AsyncMock(
+            return_value=_mock_user_row(SAMPLE_USER_SOUL)
+        )
+
+        with patch("tools.whatsapp.aiohttp.ClientSession") as mock_cls:
+            mock_cls.return_value.post.return_value.__aenter__.side_effect = (
+                aiohttp.ClientError("Connection refused")
+            )
+
+            result = await tool.execute(
+                action="send_message", user_id="ron", message="test"
+            )
+
+            assert "Error" in result
+
+    @pytest.mark.asyncio
+    async def test_timeout_error(self, tool, mock_pool):
+        mock_pool.pool.fetchrow = AsyncMock(
+            return_value=_mock_user_row(SAMPLE_USER_SOUL)
+        )
+
+        with patch("tools.whatsapp.aiohttp.ClientSession") as mock_cls:
+            mock_cls.return_value.post.return_value.__aenter__.side_effect = (
+                TimeoutError()
+            )
+
+            result = await tool.execute(
+                action="send_message", user_id="ron", message="test"
+            )
+
+            assert "timed out" in result
+
+
+# ---------------------------------------------------------------------------
+# Tests: Rate Limiting
+# ---------------------------------------------------------------------------
+
+
+class TestRateLimiting:
+    """Tests for rate limiting logic."""
+
+    @pytest.mark.asyncio
+    async def test_rate_limit_allows_under_limit(self, tool, mock_pool):
+        """Messages under the limit should succeed."""
+        mock_pool.pool.fetchrow = AsyncMock(
+            return_value=_mock_user_row(SAMPLE_USER_SOUL)
+        )
+
+        with patch("tools.whatsapp.aiohttp.ClientSession") as mock_cls:
+            mock_resp = AsyncMock()
+            mock_resp.status = 200
+            mock_resp.json = AsyncMock(return_value=SAMPLE_SEND_SUCCESS)
+            mock_cls.return_value.post.return_value.__aenter__.return_value = mock_resp
+
+            # Send 9 messages (under limit of 10)
+            for i in range(9):
+                result = await tool.execute(
+                    action="send_message",
+                    user_id="ron",
+                    message=f"Message {i}",
+                    category="general",
+                )
+                assert "sent to ron" in result
+
+    @pytest.mark.asyncio
+    async def test_rate_limit_blocks_at_limit(self, tool, mock_pool):
+        """The 11th message in an hour should be blocked."""
+        # Pre-populate rate limits with 10 recent sends
+        now = time.time()
+        tool._rate_limits["ron"] = [now - i for i in range(MAX_MESSAGES_PER_HOUR)]
+
+        mock_pool.pool.fetchrow = AsyncMock(
+            return_value=_mock_user_row(SAMPLE_USER_SOUL)
+        )
+
+        result = await tool.execute(
+            action="send_message",
+            user_id="ron",
+            message="One too many",
+            category="general",
+        )
+
+        assert "Rate limit exceeded" in result
+
+    @pytest.mark.asyncio
+    async def test_rate_limit_expires_old_entries(self, tool, mock_pool):
+        """Timestamps older than 1 hour should be pruned."""
+        # Populate with 10 timestamps from 2 hours ago
+        old = time.time() - 7200
+        tool._rate_limits["ron"] = [old - i for i in range(MAX_MESSAGES_PER_HOUR)]
+
+        mock_pool.pool.fetchrow = AsyncMock(
+            return_value=_mock_user_row(SAMPLE_USER_SOUL)
+        )
+
+        with patch("tools.whatsapp.aiohttp.ClientSession") as mock_cls:
+            mock_resp = AsyncMock()
+            mock_resp.status = 200
+            mock_resp.json = AsyncMock(return_value=SAMPLE_SEND_SUCCESS)
+            mock_cls.return_value.post.return_value.__aenter__.return_value = mock_resp
+
+            result = await tool.execute(
+                action="send_message",
+                user_id="ron",
+                message="Should work now",
+                category="general",
+            )
+
+            assert "sent to ron" in result
+            # Old entries should have been pruned
+            assert len(tool._rate_limits["ron"]) == 1
+
+
+# ---------------------------------------------------------------------------
+# Tests: Quiet Hours
+# ---------------------------------------------------------------------------
+
+
+class TestQuietHours:
+    """Tests for quiet hours logic."""
+
+    def test_is_quiet_hours_overnight_range(self):
+        """23:00-07:00 should be quiet at midnight."""
+        with patch("tools.whatsapp.datetime") as mock_dt:
+            mock_now = MagicMock()
+            mock_now.hour = 0
+            mock_now.minute = 30
+            mock_dt.now.return_value = mock_now
+            mock_dt.side_effect = lambda *a, **kw: datetime(*a, **kw)
+
+            assert WhatsAppTool._is_quiet_hours("23:00", "07:00") is True
+
+    def test_is_quiet_hours_same_day_range(self):
+        """09:00-17:00 should be quiet at noon."""
+        with patch("tools.whatsapp.datetime") as mock_dt:
+            mock_now = MagicMock()
+            mock_now.hour = 12
+            mock_now.minute = 0
+            mock_dt.now.return_value = mock_now
+            mock_dt.side_effect = lambda *a, **kw: datetime(*a, **kw)
+
+            assert WhatsAppTool._is_quiet_hours("09:00", "17:00") is True
+
+    def test_not_quiet_hours(self):
+        """23:00-07:00 should NOT be quiet at 14:00."""
+        with patch("tools.whatsapp.datetime") as mock_dt:
+            mock_now = MagicMock()
+            mock_now.hour = 14
+            mock_now.minute = 0
+            mock_dt.now.return_value = mock_now
+            mock_dt.side_effect = lambda *a, **kw: datetime(*a, **kw)
+
+            assert WhatsAppTool._is_quiet_hours("23:00", "07:00") is False
+
+    def test_invalid_quiet_hours_format(self):
+        """Invalid format should return False (no crash)."""
+        assert WhatsAppTool._is_quiet_hours("invalid", "07:00") is False
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/nanobot/tools/whatsapp.py
+++ b/nanobot/tools/whatsapp.py
@@ -1,0 +1,373 @@
+"""WhatsApp outbound notification tool for Butler.
+
+This tool allows the agent to send WhatsApp messages to users for
+proactive notifications (download complete, reminders, weather alerts, etc.).
+
+Usage:
+    The tool is automatically registered when WHATSAPP_GATEWAY_URL is configured.
+    Requires a running whatsapp-web.js gateway container (docker/messaging-stack).
+
+Example:
+    tool = WhatsAppTool(gateway_url="http://whatsapp-gateway:3000", db_pool=pool)
+    result = await tool.execute(
+        action="send_message",
+        user_id="ron",
+        message="Dune audiobook is ready in your library",
+        category="download",
+    )
+
+    # When shutting down
+    await tool.close()
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+from datetime import datetime, timezone
+from typing import Any
+
+import aiohttp
+
+from .base import Tool
+from .memory import DatabasePool
+
+logger = logging.getLogger(__name__)
+
+# Default timeout for HTTP requests (seconds)
+DEFAULT_TIMEOUT = 10
+
+# Rate limiting: max messages per user per hour
+MAX_MESSAGES_PER_HOUR = 10
+
+# Valid notification categories
+VALID_CATEGORIES = frozenset(
+    ["download", "reminder", "weather", "smart_home", "calendar", "general"]
+)
+
+# Default preferences when a user has no explicit notification_preferences
+DEFAULT_NOTIFICATION_PREFS = {
+    "enabled": True,
+    "categories": list(VALID_CATEGORIES),
+}
+
+
+class WhatsAppTool(Tool):
+    """Send outbound WhatsApp notifications via the gateway REST API.
+
+    Supports sending text messages to users and checking gateway status.
+    Enforces per-user notification preferences, rate limiting, and quiet hours.
+    """
+
+    def __init__(
+        self,
+        gateway_url: str | None = None,
+        db_pool: DatabasePool | None = None,
+        timeout: int = DEFAULT_TIMEOUT,
+    ):
+        """Initialize the WhatsApp tool.
+
+        Args:
+            gateway_url: WhatsApp gateway URL (e.g. http://whatsapp-gateway:3000)
+            db_pool: Shared database pool for user lookups
+            timeout: HTTP request timeout in seconds (default: 10)
+        """
+        self.gateway_url = (gateway_url or "").rstrip("/")
+        self._db_pool = db_pool
+        self.timeout = aiohttp.ClientTimeout(total=timeout)
+        self._session: aiohttp.ClientSession | None = None
+        # In-memory rate limiting: user_id -> list of send timestamps
+        self._rate_limits: dict[str, list[float]] = {}
+
+    async def _get_session(self) -> aiohttp.ClientSession:
+        """Get or create the HTTP session."""
+        if self._session is None or self._session.closed:
+            self._session = aiohttp.ClientSession(timeout=self.timeout)
+        return self._session
+
+    async def close(self) -> None:
+        """Close the HTTP session.
+
+        Should be called when shutting down to cleanly release connections.
+        """
+        if self._session and not self._session.closed:
+            await self._session.close()
+            self._session = None
+
+    # ------------------------------------------------------------------
+    # Tool interface
+    # ------------------------------------------------------------------
+
+    @property
+    def name(self) -> str:
+        return "whatsapp"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Send outbound WhatsApp notifications to users. Use this for "
+            "proactive messages like download complete alerts, reminders, "
+            "weather warnings, and smart home updates. Each message requires "
+            "a user_id and respects the user's notification preferences, "
+            "rate limits (max 10/hour), and quiet hours."
+        )
+
+    @property
+    def parameters(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "action": {
+                    "type": "string",
+                    "enum": ["send_message", "check_status"],
+                    "description": (
+                        "send_message: Send a WhatsApp notification to a user. "
+                        "check_status: Check if the WhatsApp gateway is connected."
+                    ),
+                },
+                "user_id": {
+                    "type": "string",
+                    "description": (
+                        "User ID to send the message to. "
+                        "The user must have a whatsapp_phone in their profile."
+                    ),
+                },
+                "message": {
+                    "type": "string",
+                    "description": "The message text to send.",
+                },
+                "category": {
+                    "type": "string",
+                    "enum": sorted(VALID_CATEGORIES),
+                    "description": (
+                        "Notification category. Must match a category the user "
+                        "has enabled. Defaults to 'general' if not specified."
+                    ),
+                },
+            },
+            "required": ["action"],
+        }
+
+    async def execute(self, **kwargs: Any) -> str:
+        action = kwargs["action"]
+
+        if not self.gateway_url:
+            return "Error: WHATSAPP_GATEWAY_URL must be configured."
+
+        try:
+            if action == "send_message":
+                return await self._send_message(
+                    user_id=kwargs.get("user_id", ""),
+                    message=kwargs.get("message", ""),
+                    category=kwargs.get("category", "general"),
+                )
+            elif action == "check_status":
+                return await self._check_status()
+            else:
+                return f"Error: Unknown action '{action}'"
+        except aiohttp.ClientError as e:
+            return f"Error connecting to WhatsApp gateway: {e}"
+        except TimeoutError:
+            return "Error: WhatsApp gateway request timed out"
+        except Exception as e:
+            return f"Error: {e}"
+
+    # ------------------------------------------------------------------
+    # Actions
+    # ------------------------------------------------------------------
+
+    async def _send_message(
+        self,
+        user_id: str,
+        message: str,
+        category: str,
+    ) -> str:
+        """Send a WhatsApp message to a user, checking preferences first."""
+        if not user_id:
+            return "Error: user_id is required for send_message"
+        if not message:
+            return "Error: message is required for send_message"
+
+        # Look up user in database
+        phone, prefs, error = await self._get_user_whatsapp_config(user_id)
+        if error:
+            return error
+
+        # Check notification preferences
+        pref_error = self._check_preferences(user_id, prefs, category)
+        if pref_error:
+            return pref_error
+
+        # Check rate limit
+        if not self._check_rate_limit(user_id):
+            return (
+                f"Rate limit exceeded for user '{user_id}' "
+                f"(max {MAX_MESSAGES_PER_HOUR} messages/hour). Try again later."
+            )
+
+        # Send via gateway
+        session = await self._get_session()
+        payload = {"to": phone, "message": message}
+
+        async with session.post(
+            f"{self.gateway_url}/send", json=payload
+        ) as resp:
+            data = await resp.json()
+
+            if resp.status != 200 and not data.get("ok"):
+                return f"Error sending WhatsApp message: {data.get('error', f'HTTP {resp.status}')}"
+
+            if not data.get("ok"):
+                return f"Error: {data.get('error', 'Unknown error')}"
+
+        # Record successful send for rate limiting
+        self._record_send(user_id)
+
+        if data.get("queued"):
+            return (
+                f"WhatsApp message to {user_id} queued for delivery "
+                "(gateway is temporarily disconnected)."
+            )
+        return f"WhatsApp message sent to {user_id}."
+
+    async def _check_status(self) -> str:
+        """Check WhatsApp gateway connection status."""
+        session = await self._get_session()
+
+        async with session.get(f"{self.gateway_url}/status") as resp:
+            if resp.status != 200:
+                return "WhatsApp gateway is not responding."
+
+            data = await resp.json()
+
+        if data.get("connected"):
+            info = data.get("info") or {}
+            name = info.get("pushname", "")
+            name_str = f" as {name}" if name else ""
+            queue = data.get("queueSize", 0)
+            queue_str = f" ({queue} queued messages)" if queue else ""
+            return f"WhatsApp gateway is connected{name_str} and ready.{queue_str}"
+
+        return (
+            "WhatsApp gateway is running but not connected to WhatsApp. "
+            "Scan the QR code to authenticate (check gateway logs)."
+        )
+
+    # ------------------------------------------------------------------
+    # User preferences
+    # ------------------------------------------------------------------
+
+    async def _get_user_whatsapp_config(
+        self, user_id: str
+    ) -> tuple[str, dict, str | None]:
+        """Look up user's WhatsApp phone and notification preferences.
+
+        Returns:
+            (phone, notification_prefs, error_message)
+            If error_message is not None, the other values are empty.
+        """
+        if not self._db_pool:
+            return "", {}, "Error: Database pool not available."
+
+        pool = self._db_pool.pool
+        row = await pool.fetchrow(
+            "SELECT soul FROM butler.users WHERE id = $1",
+            user_id,
+        )
+
+        if row is None:
+            return "", {}, f"Error: User '{user_id}' not found."
+
+        soul = row["soul"]
+        if isinstance(soul, str):
+            soul = json.loads(soul)
+        soul = soul or {}
+
+        phone = soul.get("whatsapp_phone", "")
+        if not phone:
+            return "", {}, (
+                f"User '{user_id}' does not have a WhatsApp phone configured. "
+                "Set it in their profile (soul.whatsapp_phone)."
+            )
+
+        prefs = soul.get("notification_preferences", DEFAULT_NOTIFICATION_PREFS)
+        return phone, prefs, None
+
+    def _check_preferences(
+        self, user_id: str, prefs: dict, category: str
+    ) -> str | None:
+        """Check if the user's notification preferences allow this message.
+
+        Returns an error string if blocked, None if allowed.
+        """
+        if not prefs.get("enabled", True):
+            return f"Notifications are disabled for user '{user_id}'."
+
+        allowed_categories = prefs.get("categories", list(VALID_CATEGORIES))
+        if category not in allowed_categories:
+            return (
+                f"User '{user_id}' has not opted in to '{category}' notifications."
+            )
+
+        # Check quiet hours
+        quiet_start = prefs.get("quiet_hours_start")
+        quiet_end = prefs.get("quiet_hours_end")
+        if quiet_start and quiet_end:
+            if self._is_quiet_hours(quiet_start, quiet_end):
+                return (
+                    f"Message not sent — user '{user_id}' is in quiet hours "
+                    f"({quiet_start}-{quiet_end}). Message will not be queued."
+                )
+
+        return None
+
+    @staticmethod
+    def _is_quiet_hours(start: str, end: str) -> bool:
+        """Check if the current UTC time falls within quiet hours.
+
+        Args:
+            start: Start time as "HH:MM" string
+            end: End time as "HH:MM" string
+
+        Returns:
+            True if current time is within quiet hours.
+        """
+        try:
+            now = datetime.now(timezone.utc)
+            current_minutes = now.hour * 60 + now.minute
+            start_h, start_m = map(int, start.split(":"))
+            end_h, end_m = map(int, end.split(":"))
+            start_minutes = start_h * 60 + start_m
+            end_minutes = end_h * 60 + end_m
+
+            if start_minutes <= end_minutes:
+                # Same-day range (e.g. 09:00-17:00)
+                return start_minutes <= current_minutes < end_minutes
+            else:
+                # Overnight range (e.g. 23:00-07:00)
+                return current_minutes >= start_minutes or current_minutes < end_minutes
+        except (ValueError, AttributeError):
+            return False
+
+    # ------------------------------------------------------------------
+    # Rate limiting
+    # ------------------------------------------------------------------
+
+    def _check_rate_limit(self, user_id: str) -> bool:
+        """Return True if the user is within rate limits."""
+        now = time.time()
+        one_hour_ago = now - 3600
+
+        timestamps = self._rate_limits.get(user_id, [])
+        # Prune old entries
+        timestamps = [t for t in timestamps if t > one_hour_ago]
+        self._rate_limits[user_id] = timestamps
+
+        return len(timestamps) < MAX_MESSAGES_PER_HOUR
+
+    def _record_send(self, user_id: str) -> None:
+        """Record a message send for rate limiting."""
+        if user_id not in self._rate_limits:
+            self._rate_limits[user_id] = []
+        self._rate_limits[user_id].append(time.time())


### PR DESCRIPTION
Closes #42

## Summary
- **WhatsApp Gateway** (Node.js): Express REST API wrapping whatsapp-web.js with `/send`, `/status`, `/qr`, `/health` endpoints and in-memory message queue for reliability during disconnections
- **WhatsAppTool** (Python): Outbound notification tool with `send_message` and `check_status` actions, following existing tool patterns (RadarrTool)
- **Notification preferences**: Per-user config stored in `butler.users.soul` JSONB (no migration needed) — supports enabled/disabled, category opt-in, and quiet hours
- **Rate limiting**: In-memory sliding window (max 10 messages/hour per user)
- **Docker**: New `messaging-stack` with whatsapp-web.js container (Chromium + LocalAuth session persistence)
- **35 new tests**, all 230 tests pass

## Test plan
- [x] `python3 -m pytest tools/test_whatsapp.py -v` — 35 tests pass
- [x] Full suite: `python3 -m pytest tools/ -v` — 230 tests pass
- [ ] Gateway standalone: `cd docker/messaging-stack && docker compose up --build`, then `curl http://localhost:3000/health`
- [ ] First-run QR scan: `docker logs whatsapp-gateway` to see QR code
- [ ] Integration: Set `WHATSAPP_GATEWAY_URL=http://whatsapp-gateway:3000` in `.env`, restart butler-api