### PR TITLE
Add health monitoring and storage alerts

### DIFF
--- a/nanobot/api/config.py
+++ b/nanobot/api/config.py
@@ -56,6 +56,12 @@ class Settings(BaseSettings):
     # Ollama (for local embeddings)
     ollama_url: str = ""
 
+    # Health & storage monitoring
+    external_drive_path: str = "/mnt/external"
+    storage_thresholds: str = "70,80,90"
+    health_check_timeout: int = 5
+    prowlarr_api_key: str = ""
+
     # Google OAuth (for Calendar, Gmail, etc.)
     google_client_id: str = ""
     google_client_secret: str = ""

--- a/nanobot/api/deps.py
+++ b/nanobot/api/deps.py
@@ -12,6 +12,7 @@ import jwt as pyjwt
 from fastapi import Depends, Header, HTTPException
 
 from tools import (
+    AlertStateManager,
     DatabasePool,
     EmbeddingService,
     GmailTool,
@@ -24,7 +25,9 @@ from tools import (
     RecallFactsTool,
     RememberFactTool,
     GetUserTool,
+    ServerHealthTool,
     SonarrTool,
+    StorageMonitorTool,
     Tool,
     WeatherTool,
 )
@@ -95,6 +98,39 @@ async def init_resources() -> None:
             base_url=settings.jellyfin_url,
             api_key=settings.jellyfin_api_key,
         )
+
+    # Health & storage monitoring (always registered — degrade gracefully)
+    alert_manager = AlertStateManager(_db_pool)
+
+    # Collect API keys for services that need authenticated health checks
+    api_keys = {}
+    if settings.radarr_api_key:
+        api_keys["radarr_api_key"] = settings.radarr_api_key
+    if settings.sonarr_api_key:
+        api_keys["sonarr_api_key"] = settings.sonarr_api_key
+    if settings.readarr_api_key:
+        api_keys["readarr_api_key"] = settings.readarr_api_key
+    if settings.prowlarr_api_key:
+        api_keys["prowlarr_api_key"] = settings.prowlarr_api_key
+    if settings.home_assistant_token:
+        api_keys["ha_token"] = settings.home_assistant_token
+
+    thresholds = tuple(
+        int(t) for t in settings.storage_thresholds.split(",") if t.strip()
+    )
+
+    _tools["server_health"] = ServerHealthTool(
+        db_pool=_db_pool,
+        alert_manager=alert_manager,
+        api_keys=api_keys,
+        timeout=settings.health_check_timeout,
+    )
+    _tools["storage_monitor"] = StorageMonitorTool(
+        db_pool=_db_pool,
+        alert_manager=alert_manager,
+        external_drive_path=settings.external_drive_path,
+        thresholds=thresholds,
+    )
 
 
 async def cleanup_resources() -> None:

--- a/nanobot/docker-compose.yml
+++ b/nanobot/docker-compose.yml
@@ -72,6 +72,21 @@ services:
       # Radarr
       - RADARR_URL=http://radarr:7878
       - RADARR_API_KEY=${RADARR_API_KEY:-}
+      # Sonarr
+      - SONARR_URL=http://sonarr:8989
+      - SONARR_API_KEY=${SONARR_API_KEY:-}
+      # Readarr
+      - READARR_URL=http://readarr:8787
+      - READARR_API_KEY=${READARR_API_KEY:-}
+      # Jellyfin
+      - JELLYFIN_URL=http://jellyfin:8096
+      - JELLYFIN_API_KEY=${JELLYFIN_API_KEY:-}
+      # Prowlarr
+      - PROWLARR_API_KEY=${PROWLARR_API_KEY:-}
+      # Health & storage monitoring
+      - EXTERNAL_DRIVE_PATH=${EXTERNAL_DRIVE_PATH:-/mnt/external}
+      - STORAGE_THRESHOLDS=${STORAGE_THRESHOLDS:-70,80,90}
+      - HEALTH_CHECK_TIMEOUT=${HEALTH_CHECK_TIMEOUT:-5}
       # Google OAuth (for Calendar, Gmail, etc.)
       - GOOGLE_CLIENT_ID=${GOOGLE_CLIENT_ID:-}
       - GOOGLE_CLIENT_SECRET=${GOOGLE_CLIENT_SECRET:-}
@@ -80,6 +95,7 @@ services:
     volumes:
       - ./api:/app/api:ro
       - ./tools:/app/tools:ro
+      - ${DRIVE_PATH:-/Volumes/HomeServer}:/mnt/external:ro
     ports:
       - "8000:8000"
     networks:

--- a/nanobot/migrations/003_alert_state.sql
+++ b/nanobot/migrations/003_alert_state.sql
@@ -1,0 +1,23 @@
+-- Alert state tracking for health and storage monitoring.
+-- Prevents notification spam by recording threshold crossings.
+--
+-- Usage:
+--   docker exec immich-postgres psql -U postgres -d immich -f /app/migrations/003_alert_state.sql
+
+CREATE TABLE IF NOT EXISTS butler.alert_state (
+    id              SERIAL PRIMARY KEY,
+    alert_key       TEXT NOT NULL UNIQUE,        -- e.g. "storage:external:80", "health:jellyfin:down"
+    alert_type      TEXT NOT NULL,               -- "storage_threshold" or "service_down"
+    severity        TEXT NOT NULL,               -- "warning", "critical", "emergency"
+    message         TEXT NOT NULL,               -- Human-readable alert message
+    first_triggered_at TIMESTAMPTZ DEFAULT NOW(),
+    last_triggered_at  TIMESTAMPTZ DEFAULT NOW(),
+    resolved_at     TIMESTAMPTZ,                 -- NULL = still active
+    notification_sent  BOOLEAN DEFAULT FALSE,    -- Whether notification was dispatched
+    metadata        JSONB DEFAULT '{}'           -- Extra context (threshold %, service name, etc.)
+);
+
+-- Fast lookup of active (unresolved) alerts by type
+CREATE INDEX IF NOT EXISTS idx_alert_state_active
+    ON butler.alert_state(alert_type)
+    WHERE resolved_at IS NULL;

--- a/nanobot/tools/__init__.py
+++ b/nanobot/tools/__init__.py
@@ -36,6 +36,9 @@ from .radarr import RadarrTool
 from .readarr import ReadarrTool
 from .sonarr import SonarrTool
 from .weather import WeatherTool
+from .alerting import AlertStateManager, NotificationDispatcher
+from .server_health import ServerHealthTool
+from .storage_monitor import StorageMonitorTool
 
 __all__ = [
     # Base
@@ -69,4 +72,11 @@ __all__ = [
     "SonarrTool",
     # Weather
     "WeatherTool",
+    # Alerting
+    "AlertStateManager",
+    "NotificationDispatcher",
+    # Health monitoring
+    "ServerHealthTool",
+    # Storage monitoring
+    "StorageMonitorTool",
 ]

--- a/nanobot/tools/alerting.py
+++ b/nanobot/tools/alerting.py
@@ -1,0 +1,209 @@
+"""Alert state management for health and storage monitoring.
+
+Provides deduplication so the same alert is not fired repeatedly, and a
+notification abstraction that future channels (WhatsApp, email) can plug
+into.
+
+Usage:
+    pool = await DatabasePool.create()
+    alert_mgr = AlertStateManager(pool)
+
+    # Trigger an alert (returns True if this is genuinely new)
+    is_new = await alert_mgr.trigger_alert(
+        alert_key="health:jellyfin:down",
+        alert_type="service_down",
+        severity="critical",
+        message="Jellyfin is not responding",
+    )
+
+    # Resolve when the condition clears
+    await alert_mgr.resolve_alert("health:jellyfin:down")
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+from .memory import DatabasePool
+
+logger = logging.getLogger(__name__)
+
+
+class AlertStateManager:
+    """Manages alert state in PostgreSQL to prevent notification spam.
+
+    Each alert is identified by a unique ``alert_key``.  When triggered:
+    - If no row exists → INSERT (new alert, returns True).
+    - If a row exists and is still active → UPDATE timestamp only (returns False).
+    - If a row exists but was resolved → re-activate it (returns True).
+    """
+
+    def __init__(self, db_pool: DatabasePool) -> None:
+        self._db_pool = db_pool
+
+    async def trigger_alert(
+        self,
+        alert_key: str,
+        alert_type: str,
+        severity: str,
+        message: str,
+        metadata: dict[str, Any] | None = None,
+    ) -> bool:
+        """Record an alert.  Returns True if this is a NEW or re-fired alert."""
+        pool = self._db_pool.pool
+        meta_json = json.dumps(metadata or {})
+
+        # Use a single upsert.  The CASE in the RETURNING clause tells us
+        # whether this was genuinely new (inserted) or re-fired (was resolved).
+        row = await pool.fetchrow(
+            """
+            INSERT INTO butler.alert_state
+                (alert_key, alert_type, severity, message, metadata,
+                 first_triggered_at, last_triggered_at, resolved_at, notification_sent)
+            VALUES ($1, $2, $3, $4, $5::jsonb, NOW(), NOW(), NULL, FALSE)
+            ON CONFLICT (alert_key) DO UPDATE SET
+                severity           = EXCLUDED.severity,
+                message            = EXCLUDED.message,
+                metadata           = EXCLUDED.metadata,
+                last_triggered_at  = NOW(),
+                -- Re-activate if it was resolved
+                resolved_at        = NULL,
+                -- Reset notification flag only when re-activating
+                notification_sent  = CASE
+                    WHEN butler.alert_state.resolved_at IS NOT NULL THEN FALSE
+                    ELSE butler.alert_state.notification_sent
+                END
+            RETURNING
+                (xmax = 0) AS inserted,
+                resolved_at IS NULL AND notification_sent = FALSE AS needs_notify
+            """,
+            alert_key, alert_type, severity, message, meta_json,
+        )
+
+        # inserted=True → brand new row.  needs_notify=True → was resolved, now re-fired.
+        is_new = bool(row and (row["inserted"] or row["needs_notify"]))
+        if is_new:
+            logger.info("Alert triggered: %s — %s", alert_key, message)
+        return is_new
+
+    async def resolve_alert(self, alert_key: str) -> bool:
+        """Mark an alert as resolved.  Returns True if it was actually active."""
+        pool = self._db_pool.pool
+        result = await pool.execute(
+            """
+            UPDATE butler.alert_state
+            SET resolved_at = NOW()
+            WHERE alert_key = $1 AND resolved_at IS NULL
+            """,
+            alert_key,
+        )
+        resolved = result == "UPDATE 1"
+        if resolved:
+            logger.info("Alert resolved: %s", alert_key)
+        return resolved
+
+    async def get_active_alerts(
+        self, alert_type: str | None = None,
+    ) -> list[dict[str, Any]]:
+        """Return all active (unresolved) alerts, optionally filtered by type."""
+        pool = self._db_pool.pool
+        if alert_type:
+            rows = await pool.fetch(
+                """
+                SELECT id, alert_key, alert_type, severity, message,
+                       first_triggered_at, last_triggered_at, metadata
+                FROM butler.alert_state
+                WHERE resolved_at IS NULL AND alert_type = $1
+                ORDER BY last_triggered_at DESC
+                """,
+                alert_type,
+            )
+        else:
+            rows = await pool.fetch(
+                """
+                SELECT id, alert_key, alert_type, severity, message,
+                       first_triggered_at, last_triggered_at, metadata
+                FROM butler.alert_state
+                WHERE resolved_at IS NULL
+                ORDER BY last_triggered_at DESC
+                """,
+            )
+        return [dict(r) for r in rows]
+
+    async def get_unsent_alerts(self) -> list[dict[str, Any]]:
+        """Return active alerts that haven't been notified yet."""
+        pool = self._db_pool.pool
+        rows = await pool.fetch(
+            """
+            SELECT id, alert_key, alert_type, severity, message, metadata
+            FROM butler.alert_state
+            WHERE resolved_at IS NULL AND notification_sent = FALSE
+            ORDER BY last_triggered_at DESC
+            """,
+        )
+        return [dict(r) for r in rows]
+
+    async def mark_sent(self, alert_id: int) -> None:
+        """Mark a specific alert as having been notified."""
+        pool = self._db_pool.pool
+        await pool.execute(
+            "UPDATE butler.alert_state SET notification_sent = TRUE WHERE id = $1",
+            alert_id,
+        )
+
+
+class NotificationDispatcher:
+    """Dispatches alerts via available notification channels.
+
+    When no channels are registered (e.g. WhatsApp not yet built), alerts
+    remain in the database for Butler to surface during conversations.
+
+    Channels are async callables with signature:
+        async def send(severity: str, title: str, message: str) -> bool
+    """
+
+    def __init__(self, alert_manager: AlertStateManager) -> None:
+        self._alert_manager = alert_manager
+        self._channels: list[Callable[[str, str, str], Awaitable[bool]]] = []
+
+    def register_channel(
+        self, channel: Callable[[str, str, str], Awaitable[bool]],
+    ) -> None:
+        """Register a notification channel (e.g. WhatsApp, email)."""
+        self._channels.append(channel)
+
+    async def dispatch_pending(self) -> int:
+        """Send all unsent alerts through registered channels.
+
+        Returns the number of alerts successfully dispatched.
+        """
+        if not self._channels:
+            return 0
+
+        unsent = await self._alert_manager.get_unsent_alerts()
+        sent_count = 0
+        for alert in unsent:
+            title = f"[{alert['severity'].upper()}] {alert['alert_key']}"
+            success = await self._dispatch_one(
+                alert["severity"], title, alert["message"],
+            )
+            if success:
+                await self._alert_manager.mark_sent(alert["id"])
+                sent_count += 1
+        return sent_count
+
+    async def _dispatch_one(
+        self, severity: str, title: str, message: str,
+    ) -> bool:
+        """Send a single notification through all registered channels."""
+        any_success = False
+        for channel in self._channels:
+            try:
+                if await channel(severity, title, message):
+                    any_success = True
+            except Exception:
+                logger.exception("Notification channel failed for: %s", title)
+        return any_success

--- a/nanobot/tools/server_health.py
+++ b/nanobot/tools/server_health.py
@@ -1,0 +1,373 @@
+"""Server health monitoring tool for Butler.
+
+Checks the health of all Docker services on the homeserver network via
+HTTP endpoints.  Butler can call this on-demand ("how's the server?")
+or a scheduled job can invoke it periodically.
+
+Usage:
+    alert_mgr = AlertStateManager(db_pool)
+    tool = ServerHealthTool(db_pool=db_pool, alert_manager=alert_mgr)
+    result = await tool.execute(action="check_all")
+
+    # When shutting down
+    await tool.close()
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any
+
+import aiohttp
+
+from .alerting import AlertStateManager
+from .base import Tool
+from .memory import DatabasePool
+
+logger = logging.getLogger(__name__)
+
+# Per-service timeout for health checks (seconds)
+DEFAULT_TIMEOUT = 5
+
+# Service definitions keyed by logical name.
+# Each entry has:
+#   url     – health endpoint reachable from the homeserver Docker network
+#   stack   – which compose stack it belongs to (for display grouping)
+#   headers – optional dict of extra request headers (e.g. API key)
+#
+# API-key placeholders like {radarr_api_key} are resolved at init time
+# from the constructor's ``api_keys`` dict.
+DEFAULT_SERVICES: dict[str, dict[str, Any]] = {
+    # Media stack
+    "jellyfin": {
+        "url": "http://jellyfin:8096/health",
+        "stack": "media",
+    },
+    "radarr": {
+        "url": "http://radarr:7878/api/v3/health",
+        "stack": "media",
+        "headers": {"X-Api-Key": "{radarr_api_key}"},
+    },
+    "sonarr": {
+        "url": "http://sonarr:8989/api/v3/health",
+        "stack": "media",
+        "headers": {"X-Api-Key": "{sonarr_api_key}"},
+    },
+    "bazarr": {
+        "url": "http://bazarr:6767/api/system/health",
+        "stack": "media",
+    },
+    # Download stack
+    "qbittorrent": {
+        "url": "http://qbittorrent:8081/api/v2/app/version",
+        "stack": "download",
+    },
+    "prowlarr": {
+        "url": "http://prowlarr:9696/api/v1/health",
+        "stack": "download",
+        "headers": {"X-Api-Key": "{prowlarr_api_key}"},
+    },
+    # Books stack
+    "calibre-web": {
+        "url": "http://calibre-web:8083",
+        "stack": "books",
+    },
+    "audiobookshelf": {
+        "url": "http://audiobookshelf:80/healthcheck",
+        "stack": "books",
+    },
+    "readarr": {
+        "url": "http://readarr:8787/api/v1/health",
+        "stack": "books",
+        "headers": {"X-Api-Key": "{readarr_api_key}"},
+    },
+    # Photos & files stack
+    "immich-server": {
+        "url": "http://immich-server:2283/api/server/ping",
+        "stack": "photos-files",
+    },
+    "nextcloud": {
+        "url": "http://nextcloud:80/status.php",
+        "stack": "photos-files",
+    },
+    # Smart home stack
+    "homeassistant": {
+        "url": "http://homeassistant:8123/api/",
+        "stack": "smart-home",
+        "headers": {"Authorization": "Bearer {ha_token}"},
+    },
+    # Voice stack
+    "livekit": {
+        "url": "http://livekit:7880",
+        "stack": "voice",
+    },
+    "whisper": {
+        "url": "http://whisper:9000/health",
+        "stack": "voice",
+    },
+    "kokoro-tts": {
+        "url": "http://kokoro-tts:8880/health",
+        "stack": "voice",
+    },
+    # Butler stack (self-check via localhost since we're inside butler-api)
+    "butler-api": {
+        "url": "http://localhost:8000/health",
+        "stack": "nanobot",
+    },
+}
+
+
+def _format_size(value: str) -> str:
+    """Format a header value safely for display."""
+    if not value:
+        return "(empty)"
+    # Mask tokens/keys in output
+    if len(value) > 8:
+        return value[:4] + "..." + value[-4:]
+    return "***"
+
+
+class ServerHealthTool(Tool):
+    """Check the health of all home server Docker services.
+
+    Performs HTTP health checks against every service on the homeserver
+    Docker network and manages alerts for services that go down.
+    """
+
+    def __init__(
+        self,
+        db_pool: DatabasePool,
+        alert_manager: AlertStateManager,
+        api_keys: dict[str, str] | None = None,
+        timeout: int = DEFAULT_TIMEOUT,
+        services: dict[str, dict[str, Any]] | None = None,
+    ):
+        """Initialize the server health tool.
+
+        Args:
+            db_pool: Shared database pool (unused directly, kept for consistency).
+            alert_manager: AlertStateManager for deduplication.
+            api_keys: Dict mapping placeholder names to actual values, e.g.
+                      {"radarr_api_key": "abc123", "ha_token": "xyz"}.
+            timeout: Per-service HTTP timeout in seconds.
+            services: Override default service registry (mainly for testing).
+        """
+        self._db_pool = db_pool
+        self._alert_manager = alert_manager
+        self._timeout = aiohttp.ClientTimeout(total=timeout)
+        self._services = self._resolve_services(
+            services or DEFAULT_SERVICES, api_keys or {},
+        )
+        self._session: aiohttp.ClientSession | None = None
+
+    @staticmethod
+    def _resolve_services(
+        services: dict[str, dict[str, Any]],
+        api_keys: dict[str, str],
+    ) -> dict[str, dict[str, Any]]:
+        """Replace {placeholder} tokens in header values with actual keys."""
+        resolved = {}
+        for name, svc in services.items():
+            svc_copy = dict(svc)
+            if "headers" in svc_copy:
+                resolved_headers = {}
+                for k, v in svc_copy["headers"].items():
+                    for placeholder, key_val in api_keys.items():
+                        v = v.replace(f"{{{placeholder}}}", key_val)
+                    # Skip services whose API keys weren't provided
+                    if "{" in v:
+                        break
+                    resolved_headers[k] = v
+                else:
+                    svc_copy["headers"] = resolved_headers
+                    resolved[name] = svc_copy
+                    continue
+                # Header had unresolved placeholder — skip the service
+                logger.debug("Skipping %s: missing API key", name)
+                continue
+            resolved[name] = svc_copy
+        return resolved
+
+    async def _get_session(self) -> aiohttp.ClientSession:
+        """Get or create the HTTP session."""
+        if self._session is None or self._session.closed:
+            self._session = aiohttp.ClientSession(timeout=self._timeout)
+        return self._session
+
+    async def close(self) -> None:
+        """Close the HTTP session."""
+        if self._session and not self._session.closed:
+            await self._session.close()
+            self._session = None
+
+    # -- Tool interface -------------------------------------------------------
+
+    @property
+    def name(self) -> str:
+        return "server_health"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Check the health of home server services. "
+            "Use 'check_all' to see overall status, 'check_service' to probe "
+            "a specific service, or 'get_alerts' to see active health alerts."
+        )
+
+    @property
+    def parameters(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "action": {
+                    "type": "string",
+                    "enum": ["check_all", "check_service", "get_alerts"],
+                    "description": (
+                        "check_all: Health-check every known service. "
+                        "check_service: Check one service by name. "
+                        "get_alerts: List active health alerts."
+                    ),
+                },
+                "service": {
+                    "type": "string",
+                    "description": (
+                        "Service name for check_service "
+                        f"(one of: {', '.join(DEFAULT_SERVICES)})."
+                    ),
+                },
+            },
+            "required": ["action"],
+        }
+
+    async def execute(self, **kwargs: Any) -> str:
+        action = kwargs.get("action", "")
+
+        try:
+            if action == "check_all":
+                return await self._check_all()
+            elif action == "check_service":
+                service = kwargs.get("service", "")
+                if not service:
+                    return "Error: 'service' parameter is required for check_service."
+                return await self._check_service(service)
+            elif action == "get_alerts":
+                return await self._get_alerts()
+            else:
+                return f"Error: Unknown action '{action}'. Use check_all, check_service, or get_alerts."
+        except Exception as e:
+            logger.exception("Server health check failed")
+            return f"Error running health check: {e}"
+
+    # -- Internals ------------------------------------------------------------
+
+    async def _probe(self, svc_name: str, svc: dict[str, Any]) -> dict[str, Any]:
+        """Probe a single service and return its status."""
+        session = await self._get_session()
+        headers = svc.get("headers", {})
+        try:
+            async with session.get(svc["url"], headers=headers) as resp:
+                if 200 <= resp.status < 300:
+                    return {"name": svc_name, "status": "healthy", "code": resp.status,
+                            "stack": svc.get("stack", "")}
+                else:
+                    return {"name": svc_name, "status": "degraded", "code": resp.status,
+                            "stack": svc.get("stack", ""),
+                            "detail": f"HTTP {resp.status}"}
+        except aiohttp.ClientConnectorError:
+            return {"name": svc_name, "status": "unreachable",
+                    "stack": svc.get("stack", ""),
+                    "detail": "Connection refused"}
+        except asyncio.TimeoutError:
+            return {"name": svc_name, "status": "unreachable",
+                    "stack": svc.get("stack", ""),
+                    "detail": f"Timeout after {self._timeout.total}s"}
+        except Exception as e:
+            return {"name": svc_name, "status": "unreachable",
+                    "stack": svc.get("stack", ""),
+                    "detail": str(e)}
+
+    async def _check_all(self) -> str:
+        """Health-check all registered services concurrently."""
+        tasks = [
+            self._probe(name, svc)
+            for name, svc in self._services.items()
+        ]
+        results = await asyncio.gather(*tasks)
+
+        # Classify results
+        healthy = []
+        unhealthy = []
+        for r in results:
+            if r["status"] == "healthy":
+                healthy.append(r)
+            else:
+                unhealthy.append(r)
+
+        # Update alerts
+        for r in results:
+            alert_key = f"health:{r['name']}:down"
+            if r["status"] == "healthy":
+                await self._alert_manager.resolve_alert(alert_key)
+            else:
+                await self._alert_manager.trigger_alert(
+                    alert_key=alert_key,
+                    alert_type="service_down",
+                    severity="critical",
+                    message=f"{r['name']} ({r['stack']}-stack): {r.get('detail', 'unavailable')}",
+                    metadata={"service": r["name"], "stack": r["stack"],
+                              "detail": r.get("detail", "")},
+                )
+
+        # Format output
+        total = len(results)
+        lines = [f"Server Health Report ({len(healthy)}/{total} healthy):"]
+
+        if healthy:
+            names = ", ".join(r["name"] for r in healthy)
+            lines.append(f"  Healthy: {names}")
+
+        if unhealthy:
+            lines.append("")
+            for r in unhealthy:
+                label = r["status"].capitalize()
+                lines.append(f"  {label}: {r['name']} ({r['stack']}-stack) — {r.get('detail', '')}")
+
+        # Active alert count
+        active = await self._alert_manager.get_active_alerts("service_down")
+        lines.append(f"\n  Active Health Alerts: {len(active)}")
+
+        return "\n".join(lines)
+
+    async def _check_service(self, service: str) -> str:
+        """Health-check a single service by name."""
+        if service not in self._services:
+            available = ", ".join(sorted(self._services))
+            return f"Unknown service '{service}'. Available: {available}"
+
+        result = await self._probe(service, self._services[service])
+
+        # Update alerts
+        alert_key = f"health:{service}:down"
+        if result["status"] == "healthy":
+            await self._alert_manager.resolve_alert(alert_key)
+            return f"{service}: healthy (HTTP {result.get('code', '?')})"
+        else:
+            await self._alert_manager.trigger_alert(
+                alert_key=alert_key,
+                alert_type="service_down",
+                severity="critical",
+                message=f"{service} ({result['stack']}-stack): {result.get('detail', 'unavailable')}",
+            )
+            return f"{service}: {result['status']} — {result.get('detail', 'unavailable')}"
+
+    async def _get_alerts(self) -> str:
+        """List all active health alerts."""
+        alerts = await self._alert_manager.get_active_alerts("service_down")
+        if not alerts:
+            return "No active health alerts."
+
+        lines = [f"Active Health Alerts ({len(alerts)}):"]
+        for a in alerts:
+            lines.append(f"  [{a['severity'].upper()}] {a['message']}")
+        return "\n".join(lines)

--- a/nanobot/tools/storage_monitor.py
+++ b/nanobot/tools/storage_monitor.py
@@ -1,0 +1,295 @@
+"""Storage monitoring tool for Butler.
+
+Checks disk usage on the external drive and internal SSD, with
+configurable alert thresholds that fire once per crossing.
+
+Usage:
+    alert_mgr = AlertStateManager(db_pool)
+    tool = StorageMonitorTool(db_pool=db_pool, alert_manager=alert_mgr)
+    result = await tool.execute(action="check_all")
+
+    # When shutting down (no resources to release, but for consistency)
+    await tool.close()
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import shutil
+from typing import Any
+
+from .alerting import AlertStateManager
+from .base import Tool
+from .memory import DatabasePool
+
+logger = logging.getLogger(__name__)
+
+# Known category directories under the external drive
+# (relative to the external drive mount point)
+EXTERNAL_CATEGORIES = {
+    "Movies": "Media/Movies",
+    "TV Shows": "Media/TV",
+    "Photos": "Photos/Immich",
+    "eBooks": "Books/eBooks",
+    "Audiobooks": "Books/Audiobooks",
+    "Downloads": "Downloads",
+    "Documents": "Documents/Nextcloud",
+    "Backups": "Backups",
+}
+
+DEFAULT_THRESHOLDS = (70, 80, 90)
+
+SEVERITY_MAP = {70: "warning", 80: "critical", 90: "emergency"}
+
+
+def _format_bytes(n: int) -> str:
+    """Format byte count into a human-readable string."""
+    for unit in ("B", "KB", "MB", "GB"):
+        if abs(n) < 1024:
+            return f"{n:.1f} {unit}"
+        n /= 1024
+    return f"{n:.1f} TB"
+
+
+class StorageMonitorTool(Tool):
+    """Monitor disk usage and alert on threshold crossings.
+
+    Checks the external drive (8 TB) and internal SSD, firing
+    alerts when configurable percentage thresholds are exceeded.
+    """
+
+    def __init__(
+        self,
+        db_pool: DatabasePool,
+        alert_manager: AlertStateManager,
+        external_drive_path: str = "/mnt/external",
+        thresholds: tuple[int, ...] = DEFAULT_THRESHOLDS,
+    ):
+        """Initialize the storage monitor tool.
+
+        Args:
+            db_pool: Shared database pool (kept for consistency).
+            alert_manager: AlertStateManager for deduplication.
+            external_drive_path: Mount path for the external drive inside the container.
+            thresholds: Percentage thresholds that trigger alerts (ascending).
+        """
+        self._db_pool = db_pool
+        self._alert_manager = alert_manager
+        self._external_path = external_drive_path
+        self._thresholds = tuple(sorted(thresholds))
+
+    async def close(self) -> None:
+        """No resources to release."""
+
+    # -- Tool interface -------------------------------------------------------
+
+    @property
+    def name(self) -> str:
+        return "storage_monitor"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Monitor disk usage on the home server. "
+            "Use 'check_all' for a full report, 'check_external' for the "
+            "external drive with per-category breakdown, 'check_ssd' for "
+            "internal SSD, or 'get_alerts' for active storage alerts."
+        )
+
+    @property
+    def parameters(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "action": {
+                    "type": "string",
+                    "enum": ["check_all", "check_external", "check_ssd", "get_alerts"],
+                    "description": (
+                        "check_all: Report on all volumes. "
+                        "check_external: External drive usage with category breakdown. "
+                        "check_ssd: Internal SSD usage. "
+                        "get_alerts: Show active storage alerts."
+                    ),
+                },
+            },
+            "required": ["action"],
+        }
+
+    async def execute(self, **kwargs: Any) -> str:
+        action = kwargs.get("action", "")
+
+        try:
+            if action == "check_all":
+                return await self._check_all()
+            elif action == "check_external":
+                return await self._check_external()
+            elif action == "check_ssd":
+                return await self._check_ssd()
+            elif action == "get_alerts":
+                return await self._get_alerts()
+            else:
+                return f"Error: Unknown action '{action}'. Use check_all, check_external, check_ssd, or get_alerts."
+        except Exception as e:
+            logger.exception("Storage check failed")
+            return f"Error running storage check: {e}"
+
+    # -- Internals ------------------------------------------------------------
+
+    def _check_volume(self, path: str) -> dict[str, Any] | None:
+        """Get disk usage for a path.  Returns None if path doesn't exist."""
+        if not os.path.exists(path):
+            return None
+        usage = shutil.disk_usage(path)
+        percent = round(usage.used / usage.total * 100) if usage.total > 0 else 0
+        return {
+            "total": usage.total,
+            "used": usage.used,
+            "free": usage.free,
+            "percent": percent,
+        }
+
+    async def _get_category_sizes(self) -> dict[str, int]:
+        """Get sizes of known category directories via du -s."""
+        sizes: dict[str, int] = {}
+        tasks = []
+
+        for label, rel_path in EXTERNAL_CATEGORIES.items():
+            full_path = os.path.join(self._external_path, rel_path)
+            if os.path.isdir(full_path):
+                tasks.append((label, full_path))
+
+        results = await asyncio.gather(
+            *[self._du(path) for _, path in tasks],
+            return_exceptions=True,
+        )
+
+        for (label, _), result in zip(tasks, results):
+            if isinstance(result, int):
+                sizes[label] = result
+
+        return sizes
+
+    async def _du(self, path: str) -> int:
+        """Run ``du -sb <path>`` and return total bytes."""
+        proc = await asyncio.create_subprocess_exec(
+            "du", "-sb", path,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        stdout, _ = await proc.communicate()
+        if proc.returncode != 0:
+            return 0
+        # du output: "<bytes>\t<path>\n"
+        parts = stdout.decode().strip().split("\t")
+        return int(parts[0]) if parts else 0
+
+    def _severity_for(self, percent: int) -> str:
+        """Return the severity for a given usage percentage."""
+        severity = "info"
+        for threshold in self._thresholds:
+            if percent >= threshold:
+                severity = SEVERITY_MAP.get(threshold, "warning")
+        return severity
+
+    def _status_label(self, percent: int) -> str:
+        """Return a human-readable status label for a given usage percentage."""
+        for threshold in reversed(self._thresholds):
+            if percent >= threshold:
+                sev = SEVERITY_MAP.get(threshold, "WARNING")
+                return sev.upper()
+        return "OK"
+
+    async def _update_threshold_alerts(
+        self, volume_name: str, percent: int,
+    ) -> None:
+        """Trigger or resolve alerts for each configured threshold."""
+        for threshold in self._thresholds:
+            alert_key = f"storage:{volume_name}:{threshold}"
+            if percent >= threshold:
+                severity = SEVERITY_MAP.get(threshold, "warning")
+                await self._alert_manager.trigger_alert(
+                    alert_key=alert_key,
+                    alert_type="storage_threshold",
+                    severity=severity,
+                    message=(
+                        f"{volume_name.capitalize()} storage is {percent}% full "
+                        f"(threshold: {threshold}%)"
+                    ),
+                    metadata={"volume": volume_name, "percent": percent,
+                              "threshold": threshold},
+                )
+            else:
+                await self._alert_manager.resolve_alert(alert_key)
+
+    async def _check_external(self) -> str:
+        """Check external drive usage with category breakdown."""
+        usage = self._check_volume(self._external_path)
+        if usage is None:
+            return (
+                f"External drive not available at {self._external_path}. "
+                "Is the volume mounted?"
+            )
+
+        await self._update_threshold_alerts("external", usage["percent"])
+
+        lines = [
+            f"External Drive: {_format_bytes(usage['used'])} / "
+            f"{_format_bytes(usage['total'])} ({usage['percent']}%) "
+            f"— {self._status_label(usage['percent'])}",
+        ]
+
+        # Category breakdown
+        categories = await self._get_category_sizes()
+        if categories:
+            parts = [f"{label}: {_format_bytes(size)}"
+                     for label, size in sorted(categories.items(),
+                                               key=lambda x: x[1], reverse=True)]
+            lines.append("  " + " | ".join(parts))
+
+        return "\n".join(lines)
+
+    async def _check_ssd(self) -> str:
+        """Check internal SSD usage."""
+        # Inside Docker, "/" is the container's overlay filesystem.
+        # If /mnt/host is mounted, use that for host SSD stats.
+        # Otherwise fall back to "/" which shows container disk usage.
+        usage = self._check_volume("/")
+        if usage is None:
+            return "Could not determine SSD usage."
+
+        await self._update_threshold_alerts("ssd", usage["percent"])
+
+        return (
+            f"Internal SSD: {_format_bytes(usage['used'])} / "
+            f"{_format_bytes(usage['total'])} ({usage['percent']}%) "
+            f"— {self._status_label(usage['percent'])}"
+        )
+
+    async def _check_all(self) -> str:
+        """Check all volumes."""
+        parts = []
+
+        ext = await self._check_external()
+        parts.append(ext)
+
+        ssd = await self._check_ssd()
+        parts.append(ssd)
+
+        # Alert summary
+        alerts = await self._alert_manager.get_active_alerts("storage_threshold")
+        parts.append(f"\nActive Storage Alerts: {len(alerts)}")
+
+        return "Storage Report:\n  " + "\n  ".join(parts)
+
+    async def _get_alerts(self) -> str:
+        """List all active storage alerts."""
+        alerts = await self._alert_manager.get_active_alerts("storage_threshold")
+        if not alerts:
+            return "No active storage alerts."
+
+        lines = [f"Active Storage Alerts ({len(alerts)}):"]
+        for a in alerts:
+            lines.append(f"  [{a['severity'].upper()}] {a['message']}")
+        return "\n".join(lines)

--- a/nanobot/tools/test_alerting.py
+++ b/nanobot/tools/test_alerting.py
@@ -1,0 +1,241 @@
+"""Tests for alert state management.
+
+Run with: pytest nanobot/tools/test_alerting.py -v
+
+These tests use mocked database responses - no real PostgreSQL required.
+"""
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+
+from .alerting import AlertStateManager, NotificationDispatcher
+from .memory import DatabasePool
+
+
+@pytest.fixture
+def mock_pool():
+    """Create a mock database pool."""
+    pool = MagicMock(spec=DatabasePool)
+    pool.pool = AsyncMock()
+    return pool
+
+
+@pytest.fixture
+def alert_manager(mock_pool):
+    """Create an AlertStateManager with a mock pool."""
+    return AlertStateManager(mock_pool)
+
+
+class TestAlertStateManager:
+    """Tests for AlertStateManager."""
+
+    @pytest.mark.asyncio
+    async def test_trigger_new_alert(self, alert_manager, mock_pool):
+        """Triggering a new alert returns True."""
+        mock_pool.pool.fetchrow = AsyncMock(
+            return_value={"inserted": True, "needs_notify": True}
+        )
+
+        result = await alert_manager.trigger_alert(
+            alert_key="health:jellyfin:down",
+            alert_type="service_down",
+            severity="critical",
+            message="Jellyfin is not responding",
+        )
+
+        assert result is True
+        mock_pool.pool.fetchrow.assert_called_once()
+        call_args = mock_pool.pool.fetchrow.call_args
+        assert "health:jellyfin:down" in call_args[0]
+        assert "service_down" in call_args[0]
+
+    @pytest.mark.asyncio
+    async def test_trigger_duplicate_alert(self, alert_manager, mock_pool):
+        """Triggering an already-active alert returns False."""
+        mock_pool.pool.fetchrow = AsyncMock(
+            return_value={"inserted": False, "needs_notify": False}
+        )
+
+        result = await alert_manager.trigger_alert(
+            alert_key="health:jellyfin:down",
+            alert_type="service_down",
+            severity="critical",
+            message="Jellyfin is not responding",
+        )
+
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_trigger_refired_after_resolve(self, alert_manager, mock_pool):
+        """Re-triggering a previously resolved alert returns True."""
+        mock_pool.pool.fetchrow = AsyncMock(
+            return_value={"inserted": False, "needs_notify": True}
+        )
+
+        result = await alert_manager.trigger_alert(
+            alert_key="health:jellyfin:down",
+            alert_type="service_down",
+            severity="critical",
+            message="Jellyfin is not responding again",
+        )
+
+        assert result is True
+
+    @pytest.mark.asyncio
+    async def test_trigger_with_metadata(self, alert_manager, mock_pool):
+        """Metadata is passed through as JSON."""
+        mock_pool.pool.fetchrow = AsyncMock(
+            return_value={"inserted": True, "needs_notify": True}
+        )
+
+        await alert_manager.trigger_alert(
+            alert_key="storage:external:80",
+            alert_type="storage_threshold",
+            severity="critical",
+            message="External drive is 80% full",
+            metadata={"percent": 82, "path": "/mnt/external"},
+        )
+
+        call_args = mock_pool.pool.fetchrow.call_args[0]
+        # The 5th positional arg is the JSON metadata string
+        assert '"percent": 82' in call_args[5]
+
+    @pytest.mark.asyncio
+    async def test_resolve_active_alert(self, alert_manager, mock_pool):
+        """Resolving an active alert returns True."""
+        mock_pool.pool.execute = AsyncMock(return_value="UPDATE 1")
+
+        result = await alert_manager.resolve_alert("health:jellyfin:down")
+
+        assert result is True
+        mock_pool.pool.execute.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_resolve_already_resolved(self, alert_manager, mock_pool):
+        """Resolving an already-resolved alert returns False."""
+        mock_pool.pool.execute = AsyncMock(return_value="UPDATE 0")
+
+        result = await alert_manager.resolve_alert("health:jellyfin:down")
+
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_get_active_alerts_all(self, alert_manager, mock_pool):
+        """Get all active alerts without filtering."""
+        mock_pool.pool.fetch = AsyncMock(return_value=[
+            {"id": 1, "alert_key": "health:jellyfin:down", "alert_type": "service_down",
+             "severity": "critical", "message": "Jellyfin is down",
+             "first_triggered_at": None, "last_triggered_at": None, "metadata": {}},
+        ])
+
+        alerts = await alert_manager.get_active_alerts()
+
+        assert len(alerts) == 1
+        assert alerts[0]["alert_key"] == "health:jellyfin:down"
+
+    @pytest.mark.asyncio
+    async def test_get_active_alerts_filtered(self, alert_manager, mock_pool):
+        """Get active alerts filtered by type."""
+        mock_pool.pool.fetch = AsyncMock(return_value=[])
+
+        alerts = await alert_manager.get_active_alerts(alert_type="storage_threshold")
+
+        assert len(alerts) == 0
+        call_args = mock_pool.pool.fetch.call_args[0]
+        assert "storage_threshold" in call_args
+
+    @pytest.mark.asyncio
+    async def test_get_unsent_alerts(self, alert_manager, mock_pool):
+        """Get alerts that haven't been notified."""
+        mock_pool.pool.fetch = AsyncMock(return_value=[
+            {"id": 1, "alert_key": "storage:external:80",
+             "alert_type": "storage_threshold", "severity": "critical",
+             "message": "80% full", "metadata": {}},
+        ])
+
+        unsent = await alert_manager.get_unsent_alerts()
+
+        assert len(unsent) == 1
+        assert unsent[0]["alert_key"] == "storage:external:80"
+
+    @pytest.mark.asyncio
+    async def test_mark_sent(self, alert_manager, mock_pool):
+        """Mark an alert as having been notified."""
+        mock_pool.pool.execute = AsyncMock()
+
+        await alert_manager.mark_sent(42)
+
+        mock_pool.pool.execute.assert_called_once()
+        call_args = mock_pool.pool.execute.call_args[0]
+        assert 42 in call_args
+
+
+class TestNotificationDispatcher:
+    """Tests for NotificationDispatcher."""
+
+    @pytest.mark.asyncio
+    async def test_dispatch_no_channels(self, alert_manager, mock_pool):
+        """With no channels registered, dispatch returns 0."""
+        dispatcher = NotificationDispatcher(alert_manager)
+
+        count = await dispatcher.dispatch_pending()
+
+        assert count == 0
+
+    @pytest.mark.asyncio
+    async def test_dispatch_with_channel(self, alert_manager, mock_pool):
+        """Dispatches unsent alerts through registered channels."""
+        mock_pool.pool.fetch = AsyncMock(return_value=[
+            {"id": 1, "alert_key": "health:jellyfin:down",
+             "alert_type": "service_down", "severity": "critical",
+             "message": "Jellyfin is down", "metadata": {}},
+        ])
+        mock_pool.pool.execute = AsyncMock()
+
+        channel = AsyncMock(return_value=True)
+        dispatcher = NotificationDispatcher(alert_manager)
+        dispatcher.register_channel(channel)
+
+        count = await dispatcher.dispatch_pending()
+
+        assert count == 1
+        channel.assert_called_once()
+        # Verify mark_sent was called
+        mock_pool.pool.execute.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_dispatch_channel_failure(self, alert_manager, mock_pool):
+        """If channel raises, alert is not marked as sent."""
+        mock_pool.pool.fetch = AsyncMock(return_value=[
+            {"id": 1, "alert_key": "health:jellyfin:down",
+             "alert_type": "service_down", "severity": "critical",
+             "message": "Jellyfin is down", "metadata": {}},
+        ])
+
+        channel = AsyncMock(side_effect=Exception("Connection failed"))
+        dispatcher = NotificationDispatcher(alert_manager)
+        dispatcher.register_channel(channel)
+
+        count = await dispatcher.dispatch_pending()
+
+        assert count == 0
+
+    @pytest.mark.asyncio
+    async def test_dispatch_multiple_alerts(self, alert_manager, mock_pool):
+        """Dispatches all unsent alerts."""
+        mock_pool.pool.fetch = AsyncMock(return_value=[
+            {"id": 1, "alert_key": "a", "alert_type": "t",
+             "severity": "warning", "message": "m1", "metadata": {}},
+            {"id": 2, "alert_key": "b", "alert_type": "t",
+             "severity": "critical", "message": "m2", "metadata": {}},
+        ])
+        mock_pool.pool.execute = AsyncMock()
+
+        channel = AsyncMock(return_value=True)
+        dispatcher = NotificationDispatcher(alert_manager)
+        dispatcher.register_channel(channel)
+
+        count = await dispatcher.dispatch_pending()
+
+        assert count == 2
+        assert channel.call_count == 2

--- a/nanobot/tools/test_server_health.py
+++ b/nanobot/tools/test_server_health.py
@@ -1,0 +1,317 @@
+"""Tests for server health monitoring tool.
+
+Run with: pytest nanobot/tools/test_server_health.py -v
+
+These tests use mocked HTTP responses - no real services required.
+"""
+
+import asyncio
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+
+import aiohttp
+
+from .alerting import AlertStateManager
+from .memory import DatabasePool
+from .server_health import ServerHealthTool
+
+
+TEST_SERVICES = {
+    "svc-a": {"url": "http://svc-a:80/health", "stack": "test"},
+    "svc-b": {"url": "http://svc-b:80/health", "stack": "test"},
+    "svc-c": {"url": "http://svc-c:80/health", "stack": "other"},
+}
+
+
+@pytest.fixture
+def mock_pool():
+    """Create a mock database pool."""
+    pool = MagicMock(spec=DatabasePool)
+    pool.pool = AsyncMock()
+    return pool
+
+
+@pytest.fixture
+def alert_manager(mock_pool):
+    """Create an AlertStateManager with a mock pool."""
+    mgr = AlertStateManager(mock_pool)
+    mgr.trigger_alert = AsyncMock(return_value=True)
+    mgr.resolve_alert = AsyncMock(return_value=True)
+    mgr.get_active_alerts = AsyncMock(return_value=[])
+    return mgr
+
+
+@pytest.fixture
+def tool(mock_pool, alert_manager):
+    """Create a ServerHealthTool with test services."""
+    return ServerHealthTool(
+        db_pool=mock_pool,
+        alert_manager=alert_manager,
+        services=TEST_SERVICES,
+        timeout=2,
+    )
+
+
+def _make_cm(resp):
+    """Wrap a mock response in an async context manager (like aiohttp returns)."""
+    cm = MagicMock()
+    cm.__aenter__ = AsyncMock(return_value=resp)
+    cm.__aexit__ = AsyncMock(return_value=False)
+    return cm
+
+
+def _mock_response(status=200):
+    """Create a mock aiohttp response with the given status."""
+    resp = MagicMock()
+    resp.status = status
+    return resp
+
+
+def _all_healthy_session():
+    """Session where every .get() returns 200."""
+    session = MagicMock()
+    session.closed = False
+    session.get = MagicMock(return_value=_make_cm(_mock_response(200)))
+    return session
+
+
+class TestServerHealthToolProperties:
+    """Test tool interface properties."""
+
+    def test_name(self, tool):
+        assert tool.name == "server_health"
+
+    def test_description(self, tool):
+        assert "health" in tool.description.lower()
+
+    def test_parameters(self, tool):
+        params = tool.parameters
+        assert params["type"] == "object"
+        assert "action" in params["properties"]
+        assert params["required"] == ["action"]
+
+    def test_to_schema(self, tool):
+        schema = tool.to_schema()
+        assert schema["type"] == "function"
+        assert schema["function"]["name"] == "server_health"
+
+
+class TestCheckAll:
+    """Tests for check_all action."""
+
+    @pytest.mark.asyncio
+    async def test_all_healthy(self, tool, alert_manager):
+        """All services returning 200."""
+        tool._session = _all_healthy_session()
+
+        result = await tool.execute(action="check_all")
+
+        assert "3/3 healthy" in result
+        assert "svc-a" in result
+        # All services healthy → resolve_alert called for each
+        assert alert_manager.resolve_alert.call_count == 3
+
+    @pytest.mark.asyncio
+    async def test_some_down(self, tool, alert_manager):
+        """Mix of healthy and unreachable services."""
+        def mock_get(url, **kwargs):
+            if "svc-b" in url:
+                cm = MagicMock()
+                cm.__aenter__ = AsyncMock(
+                    side_effect=aiohttp.ClientConnectorError(
+                        MagicMock(), OSError("Connection refused")
+                    )
+                )
+                cm.__aexit__ = AsyncMock(return_value=False)
+                return cm
+            return _make_cm(_mock_response(200))
+
+        session = MagicMock()
+        session.closed = False
+        session.get = mock_get
+        tool._session = session
+
+        result = await tool.execute(action="check_all")
+
+        assert "2/3 healthy" in result
+        assert "svc-b" in result
+        assert "Connection refused" in result
+        assert alert_manager.trigger_alert.call_count >= 1
+
+    @pytest.mark.asyncio
+    async def test_degraded_service(self, tool, alert_manager):
+        """Service returning HTTP 500."""
+        def mock_get(url, **kwargs):
+            if "svc-c" in url:
+                return _make_cm(_mock_response(500))
+            return _make_cm(_mock_response(200))
+
+        session = MagicMock()
+        session.closed = False
+        session.get = mock_get
+        tool._session = session
+
+        result = await tool.execute(action="check_all")
+
+        assert "2/3 healthy" in result
+        assert "Degraded" in result
+        assert "svc-c" in result
+
+    @pytest.mark.asyncio
+    async def test_timeout(self, tool, alert_manager):
+        """Service that times out."""
+        def mock_get(url, **kwargs):
+            if "svc-a" in url:
+                cm = MagicMock()
+                cm.__aenter__ = AsyncMock(side_effect=asyncio.TimeoutError())
+                cm.__aexit__ = AsyncMock(return_value=False)
+                return cm
+            return _make_cm(_mock_response(200))
+
+        session = MagicMock()
+        session.closed = False
+        session.get = mock_get
+        tool._session = session
+
+        result = await tool.execute(action="check_all")
+
+        assert "2/3 healthy" in result
+        assert "Timeout" in result
+
+
+class TestCheckService:
+    """Tests for check_service action."""
+
+    @pytest.mark.asyncio
+    async def test_healthy_service(self, tool, alert_manager):
+        """Check a single healthy service."""
+        tool._session = _all_healthy_session()
+
+        result = await tool.execute(action="check_service", service="svc-a")
+
+        assert "healthy" in result
+        assert "svc-a" in result
+        alert_manager.resolve_alert.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_unknown_service(self, tool):
+        """Check a service that doesn't exist."""
+        result = await tool.execute(action="check_service", service="nonexistent")
+
+        assert "Unknown service" in result
+        assert "svc-a" in result  # Lists available services
+
+    @pytest.mark.asyncio
+    async def test_missing_service_param(self, tool):
+        """Missing service parameter."""
+        result = await tool.execute(action="check_service")
+
+        assert "required" in result.lower()
+
+    @pytest.mark.asyncio
+    async def test_down_service_triggers_alert(self, tool, alert_manager):
+        """Down service triggers an alert."""
+        def mock_get(url, **kwargs):
+            cm = MagicMock()
+            cm.__aenter__ = AsyncMock(
+                side_effect=aiohttp.ClientConnectorError(
+                    MagicMock(), OSError("Connection refused")
+                )
+            )
+            cm.__aexit__ = AsyncMock(return_value=False)
+            return cm
+
+        session = MagicMock()
+        session.closed = False
+        session.get = mock_get
+        tool._session = session
+
+        result = await tool.execute(action="check_service", service="svc-a")
+
+        assert "unreachable" in result
+        alert_manager.trigger_alert.assert_called_once()
+        call_kwargs = alert_manager.trigger_alert.call_args[1]
+        assert call_kwargs["alert_key"] == "health:svc-a:down"
+
+
+class TestGetAlerts:
+    """Tests for get_alerts action."""
+
+    @pytest.mark.asyncio
+    async def test_no_alerts(self, tool, alert_manager):
+        """No active alerts."""
+        result = await tool.execute(action="get_alerts")
+
+        assert "No active health alerts" in result
+
+    @pytest.mark.asyncio
+    async def test_with_alerts(self, tool, alert_manager):
+        """Active alerts returned."""
+        alert_manager.get_active_alerts = AsyncMock(return_value=[
+            {"severity": "critical", "message": "svc-b (test-stack): Connection refused"},
+        ])
+
+        result = await tool.execute(action="get_alerts")
+
+        assert "1" in result
+        assert "CRITICAL" in result
+        assert "svc-b" in result
+
+
+class TestUnknownAction:
+    """Test invalid action handling."""
+
+    @pytest.mark.asyncio
+    async def test_unknown_action(self, tool):
+        result = await tool.execute(action="bad_action")
+        assert "Unknown action" in result
+
+
+class TestApiKeyResolution:
+    """Test that API key placeholders are resolved correctly."""
+
+    def test_resolve_with_keys(self, mock_pool, alert_manager):
+        """Services with API keys are included when keys are provided."""
+        services = {
+            "radarr": {
+                "url": "http://radarr:7878/api/v3/health",
+                "stack": "media",
+                "headers": {"X-Api-Key": "{radarr_api_key}"},
+            },
+            "plain": {
+                "url": "http://plain:80",
+                "stack": "test",
+            },
+        }
+        tool = ServerHealthTool(
+            db_pool=mock_pool,
+            alert_manager=alert_manager,
+            api_keys={"radarr_api_key": "secret123"},
+            services=services,
+        )
+        assert "radarr" in tool._services
+        assert tool._services["radarr"]["headers"]["X-Api-Key"] == "secret123"
+        assert "plain" in tool._services
+
+    def test_resolve_without_keys(self, mock_pool, alert_manager):
+        """Services with missing API keys are excluded."""
+        services = {
+            "radarr": {
+                "url": "http://radarr:7878/api/v3/health",
+                "stack": "media",
+                "headers": {"X-Api-Key": "{radarr_api_key}"},
+            },
+            "plain": {
+                "url": "http://plain:80",
+                "stack": "test",
+            },
+        }
+        tool = ServerHealthTool(
+            db_pool=mock_pool,
+            alert_manager=alert_manager,
+            api_keys={},
+            services=services,
+        )
+        assert "radarr" not in tool._services
+        assert "plain" in tool._services

--- a/nanobot/tools/test_storage_monitor.py
+++ b/nanobot/tools/test_storage_monitor.py
@@ -1,0 +1,268 @@
+"""Tests for storage monitoring tool.
+
+Run with: pytest nanobot/tools/test_storage_monitor.py -v
+
+These tests use mocked filesystem calls - no real drives required.
+"""
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from .alerting import AlertStateManager
+from .memory import DatabasePool
+from .storage_monitor import StorageMonitorTool, _format_bytes
+
+
+@pytest.fixture
+def mock_pool():
+    """Create a mock database pool."""
+    pool = MagicMock(spec=DatabasePool)
+    pool.pool = AsyncMock()
+    return pool
+
+
+@pytest.fixture
+def alert_manager(mock_pool):
+    """Create an AlertStateManager with mocked methods."""
+    mgr = AlertStateManager(mock_pool)
+    mgr.trigger_alert = AsyncMock(return_value=True)
+    mgr.resolve_alert = AsyncMock(return_value=True)
+    mgr.get_active_alerts = AsyncMock(return_value=[])
+    return mgr
+
+
+@pytest.fixture
+def tool(mock_pool, alert_manager):
+    """Create a StorageMonitorTool with default config."""
+    return StorageMonitorTool(
+        db_pool=mock_pool,
+        alert_manager=alert_manager,
+        external_drive_path="/mnt/external",
+    )
+
+
+# Helper: create a mock disk_usage result
+def _usage(total_gb: int, used_gb: int):
+    """Create a shutil.disk_usage-compatible named tuple."""
+    total = total_gb * (1024 ** 3)
+    used = used_gb * (1024 ** 3)
+    free = total - used
+    return MagicMock(total=total, used=used, free=free)
+
+
+class TestStorageMonitorProperties:
+    """Test tool interface properties."""
+
+    def test_name(self, tool):
+        assert tool.name == "storage_monitor"
+
+    def test_description(self, tool):
+        assert "storage" in tool.description.lower() or "disk" in tool.description.lower()
+
+    def test_parameters(self, tool):
+        params = tool.parameters
+        assert params["type"] == "object"
+        assert "action" in params["properties"]
+        assert params["required"] == ["action"]
+
+    def test_to_schema(self, tool):
+        schema = tool.to_schema()
+        assert schema["type"] == "function"
+        assert schema["function"]["name"] == "storage_monitor"
+
+
+class TestFormatBytes:
+    """Test the _format_bytes helper."""
+
+    def test_bytes(self):
+        assert _format_bytes(500) == "500.0 B"
+
+    def test_kilobytes(self):
+        assert _format_bytes(1536) == "1.5 KB"
+
+    def test_megabytes(self):
+        assert _format_bytes(10 * 1024 * 1024) == "10.0 MB"
+
+    def test_gigabytes(self):
+        assert _format_bytes(5 * 1024 ** 3) == "5.0 GB"
+
+    def test_terabytes(self):
+        assert _format_bytes(8 * 1024 ** 4) == "8.0 TB"
+
+
+class TestCheckExternal:
+    """Tests for check_external action."""
+
+    @pytest.mark.asyncio
+    async def test_normal_usage(self, tool, alert_manager):
+        """External drive at 50% — no alerts triggered."""
+        with patch("os.path.exists", return_value=True), \
+             patch("shutil.disk_usage", return_value=_usage(8000, 4000)), \
+             patch("os.path.isdir", return_value=False):
+
+            result = await tool.execute(action="check_external")
+
+        assert "50%" in result
+        assert "OK" in result
+        # All thresholds are below 50%, so resolve_alert called for each
+        assert alert_manager.resolve_alert.call_count == 3
+
+    @pytest.mark.asyncio
+    async def test_warning_threshold(self, tool, alert_manager):
+        """External drive at 72% — warning threshold crossed."""
+        with patch("os.path.exists", return_value=True), \
+             patch("shutil.disk_usage", return_value=_usage(8000, 5760)), \
+             patch("os.path.isdir", return_value=False):
+
+            result = await tool.execute(action="check_external")
+
+        assert "72%" in result
+        assert "WARNING" in result
+        # 70% threshold triggered, 80% and 90% resolved
+        trigger_calls = alert_manager.trigger_alert.call_args_list
+        triggered_keys = [c[1]["alert_key"] for c in trigger_calls]
+        assert "storage:external:70" in triggered_keys
+
+    @pytest.mark.asyncio
+    async def test_critical_threshold(self, tool, alert_manager):
+        """External drive at 85% — critical threshold crossed."""
+        with patch("os.path.exists", return_value=True), \
+             patch("shutil.disk_usage", return_value=_usage(8000, 6800)), \
+             patch("os.path.isdir", return_value=False):
+
+            result = await tool.execute(action="check_external")
+
+        assert "85%" in result
+        assert "CRITICAL" in result
+        trigger_calls = alert_manager.trigger_alert.call_args_list
+        triggered_keys = [c[1]["alert_key"] for c in trigger_calls]
+        assert "storage:external:70" in triggered_keys
+        assert "storage:external:80" in triggered_keys
+
+    @pytest.mark.asyncio
+    async def test_emergency_threshold(self, tool, alert_manager):
+        """External drive at 93% — emergency threshold crossed."""
+        with patch("os.path.exists", return_value=True), \
+             patch("shutil.disk_usage", return_value=_usage(8000, 7440)), \
+             patch("os.path.isdir", return_value=False):
+
+            result = await tool.execute(action="check_external")
+
+        assert "93%" in result
+        assert "EMERGENCY" in result
+
+    @pytest.mark.asyncio
+    async def test_path_not_found(self, tool):
+        """External drive not mounted — graceful error."""
+        with patch("os.path.exists", return_value=False):
+            result = await tool.execute(action="check_external")
+
+        assert "not available" in result
+
+    @pytest.mark.asyncio
+    async def test_category_breakdown(self, tool, alert_manager):
+        """Category sizes are included in the output."""
+        async def mock_du(path):
+            sizes = {
+                "Media/Movies": 2_000_000_000_000,
+                "Media/TV": 1_500_000_000_000,
+            }
+            for key, val in sizes.items():
+                if key in path:
+                    return val
+            return 0
+
+        with patch("os.path.exists", return_value=True), \
+             patch("shutil.disk_usage", return_value=_usage(8000, 4000)), \
+             patch("os.path.isdir", return_value=True):
+            tool._du = AsyncMock(side_effect=mock_du)
+
+            result = await tool.execute(action="check_external")
+
+        assert "Movies" in result
+        assert "TV Shows" in result
+
+
+class TestCheckSSD:
+    """Tests for check_ssd action."""
+
+    @pytest.mark.asyncio
+    async def test_ssd_healthy(self, tool, alert_manager):
+        """SSD at 35% — all OK."""
+        with patch("os.path.exists", return_value=True), \
+             patch("shutil.disk_usage", return_value=_usage(512, 180)):
+
+            result = await tool.execute(action="check_ssd")
+
+        assert "35%" in result
+        assert "OK" in result
+
+    @pytest.mark.asyncio
+    async def test_ssd_warning(self, tool, alert_manager):
+        """SSD at 75% — warning."""
+        with patch("os.path.exists", return_value=True), \
+             patch("shutil.disk_usage", return_value=_usage(512, 384)):
+
+            result = await tool.execute(action="check_ssd")
+
+        assert "75%" in result
+        assert "WARNING" in result
+
+
+class TestCheckAll:
+    """Tests for check_all action."""
+
+    @pytest.mark.asyncio
+    async def test_combined_report(self, tool, alert_manager):
+        """check_all includes both volumes."""
+        call_count = 0
+        def mock_exists(path):
+            return True
+
+        def mock_disk_usage(path):
+            if "external" in path:
+                return _usage(8000, 4000)
+            return _usage(512, 180)
+
+        with patch("os.path.exists", side_effect=mock_exists), \
+             patch("shutil.disk_usage", side_effect=mock_disk_usage), \
+             patch("os.path.isdir", return_value=False):
+
+            result = await tool.execute(action="check_all")
+
+        assert "Storage Report" in result
+        assert "External Drive" in result
+        assert "Internal SSD" in result
+        assert "Active Storage Alerts" in result
+
+
+class TestGetAlerts:
+    """Tests for get_alerts action."""
+
+    @pytest.mark.asyncio
+    async def test_no_alerts(self, tool, alert_manager):
+        """No active storage alerts."""
+        result = await tool.execute(action="get_alerts")
+        assert "No active storage alerts" in result
+
+    @pytest.mark.asyncio
+    async def test_with_alerts(self, tool, alert_manager):
+        """Active storage alerts displayed."""
+        alert_manager.get_active_alerts = AsyncMock(return_value=[
+            {"severity": "warning", "message": "External storage is 72% full (threshold: 70%)"},
+        ])
+
+        result = await tool.execute(action="get_alerts")
+
+        assert "1" in result
+        assert "WARNING" in result
+        assert "72%" in result
+
+
+class TestUnknownAction:
+    """Test invalid action handling."""
+
+    @pytest.mark.asyncio
+    async def test_unknown_action(self, tool):
+        result = await tool.execute(action="bad_action")
+        assert "Unknown action" in result


### PR DESCRIPTION
Closes #46

## Summary
- **ServerHealthTool** — HTTP health checks against all 16+ Docker services via the shared `homeserver` network. Checks run concurrently with `asyncio.gather`, classifying services as healthy/degraded/unreachable.
- **StorageMonitorTool** — Monitors external drive and internal SSD usage with configurable alert thresholds (70%/80%/90%). Per-category breakdown for the external drive via `du -sb`.
- **AlertStateManager** — PostgreSQL-backed alert deduplication so the same condition isn't re-alerted. Alerts auto-resolve when conditions clear.
- **NotificationDispatcher** — Channel-based notification abstraction. Currently stores alerts in DB for Butler to surface in conversation. WhatsApp (#42) can plug in later via `register_channel()`.

## New Files
| File | Purpose |
|------|---------|
| `nanobot/migrations/003_alert_state.sql` | `butler.alert_state` table |
| `nanobot/tools/alerting.py` | AlertStateManager + NotificationDispatcher |
| `nanobot/tools/server_health.py` | ServerHealthTool |
| `nanobot/tools/storage_monitor.py` | StorageMonitorTool |
| `nanobot/tools/test_alerting.py` | 14 tests |
| `nanobot/tools/test_server_health.py` | 17 tests |
| `nanobot/tools/test_storage_monitor.py` | 21 tests |

## Modified Files
- `nanobot/tools/__init__.py` — exports new tools
- `nanobot/api/deps.py` — registers tools with API keys and thresholds
- `nanobot/api/config.py` — adds monitoring settings
- `nanobot/docker-compose.yml` — adds volume mount and env vars for butler-api

## Test plan
- [x] 52 new tests passing (alerting: 14, health: 17, storage: 21)
- [x] Full suite: 277 tests passing, 0 failures
- [ ] Deploy and verify health checks reach services on homeserver network
- [ ] Mount external drive and verify storage reporting