### PR TITLE
Build Phone Location Tool for presence detection (#40)

### DIFF
--- a/nanobot/api/deps.py
+++ b/nanobot/api/deps.py
@@ -21,6 +21,7 @@ from tools import (
     ImmichTool,
     JellyfinTool,
     ListEntitiesByDomainTool,
+    PhoneLocationTool,
     RadarrTool,
     ReadarrTool,
     RecallFactsTool,
@@ -62,6 +63,10 @@ async def init_resources() -> None:
             token=settings.home_assistant_token,
         )
         _tools["list_ha_entities"] = ListEntitiesByDomainTool(
+            base_url=settings.home_assistant_url,
+            token=settings.home_assistant_token,
+        )
+        _tools["phone_location"] = PhoneLocationTool(
             base_url=settings.home_assistant_url,
             token=settings.home_assistant_token,
         )

--- a/nanobot/tools/__init__.py
+++ b/nanobot/tools/__init__.py
@@ -36,6 +36,7 @@ from .radarr import RadarrTool
 from .readarr import ReadarrTool
 from .sonarr import SonarrTool
 from .immich import ImmichTool
+from .phone_location import PhoneLocationTool
 from .weather import WeatherTool
 from .alerting import AlertStateManager, NotificationDispatcher
 from .server_health import ServerHealthTool
@@ -65,6 +66,8 @@ __all__ = [
     "GoogleCalendarTool",
     # Jellyfin
     "JellyfinTool",
+    # Phone Location
+    "PhoneLocationTool",
     # Radarr
     "RadarrTool",
     # Readarr

--- a/nanobot/tools/phone_location.py
+++ b/nanobot/tools/phone_location.py
@@ -1,0 +1,292 @@
+"""Phone location tool for Butler.
+
+Read-only tool that queries Home Assistant person entities to determine
+household members' locations, home/away status, and distance from home.
+
+Usage:
+    tool = PhoneLocationTool(
+        base_url="http://homeassistant:8123",
+        token="your-long-lived-access-token",
+    )
+    result = await tool.execute(action="is_home", name="ron")
+
+    # When shutting down
+    await tool.close()
+
+Requires:
+    - Home Assistant with Companion App installed on household phones
+    - person.* entities configured in Home Assistant
+    - Long-lived access token with read access
+
+API Reference:
+    https://developers.home-assistant.io/docs/api/rest/
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Any
+
+import aiohttp
+
+from .base import Tool
+
+# Default timeout for HTTP requests (seconds)
+DEFAULT_TIMEOUT = 10
+
+# Earth radius in kilometres (mean radius)
+EARTH_RADIUS_KM = 6371.0
+
+
+def _haversine(lat1: float, lon1: float, lat2: float, lon2: float) -> float:
+    """Calculate the great-circle distance between two points in km."""
+    lat1, lon1, lat2, lon2 = map(math.radians, [lat1, lon1, lat2, lon2])
+    dlat = lat2 - lat1
+    dlon = lon2 - lon1
+    a = math.sin(dlat / 2) ** 2 + math.cos(lat1) * math.cos(lat2) * math.sin(dlon / 2) ** 2
+    return EARTH_RADIUS_KM * 2 * math.atan2(math.sqrt(a), math.sqrt(1 - a))
+
+
+class PhoneLocationTool(Tool):
+    """Query household members' phone locations via Home Assistant.
+
+    Uses HA person entities (which aggregate device_tracker sources like
+    the Companion App, router presence, Bluetooth, etc.) to provide
+    home/away status, GPS coordinates, and distance-from-home calculations.
+
+    Strictly read-only — no location broadcasting or modification.
+    """
+
+    def __init__(
+        self,
+        base_url: str | None = None,
+        token: str | None = None,
+        timeout: int = DEFAULT_TIMEOUT,
+    ):
+        """Initialize the phone location tool.
+
+        Args:
+            base_url: Home Assistant URL (e.g., http://homeassistant:8123)
+            token: Long-lived access token
+            timeout: HTTP request timeout in seconds (default: 10)
+        """
+        self.base_url = (base_url or "").rstrip("/")
+        self.token = token or ""
+        self.timeout = aiohttp.ClientTimeout(total=timeout)
+        self._session: aiohttp.ClientSession | None = None
+        self._home_coords: tuple[float, float] | None = None
+
+    async def _get_session(self) -> aiohttp.ClientSession:
+        """Get or create the HTTP session."""
+        if self._session is None or self._session.closed:
+            self._session = aiohttp.ClientSession(
+                headers={
+                    "Authorization": f"Bearer {self.token}",
+                    "Content-Type": "application/json",
+                },
+                timeout=self.timeout,
+            )
+        return self._session
+
+    async def close(self) -> None:
+        """Close the HTTP session."""
+        if self._session and not self._session.closed:
+            await self._session.close()
+            self._session = None
+
+    @property
+    def name(self) -> str:
+        return "phone_location"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Check household members' phone locations. "
+            "Can determine if someone is home or away, get their current zone, "
+            "list all tracked people, or calculate distance from home. Read-only."
+        )
+
+    @property
+    def parameters(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "action": {
+                    "type": "string",
+                    "enum": ["locate", "is_home", "list_people", "distance_from_home"],
+                    "description": (
+                        "locate: get a person's current location and zone. "
+                        "is_home: check if a person is home (true/false). "
+                        "list_people: show all tracked people with status. "
+                        "distance_from_home: calculate km from home."
+                    ),
+                },
+                "name": {
+                    "type": "string",
+                    "description": (
+                        "Person name as configured in Home Assistant "
+                        "(e.g., 'ron', 'alice'). Required for locate, is_home, "
+                        "and distance_from_home."
+                    ),
+                },
+            },
+            "required": ["action"],
+        }
+
+    async def execute(self, **kwargs: Any) -> str:
+        action = kwargs["action"]
+
+        if not self.base_url or not self.token:
+            return "Error: HOME_ASSISTANT_URL and HOME_ASSISTANT_TOKEN must be configured."
+
+        try:
+            if action == "locate":
+                return await self._locate(kwargs.get("name"))
+            elif action == "is_home":
+                return await self._is_home(kwargs.get("name"))
+            elif action == "list_people":
+                return await self._list_people()
+            elif action == "distance_from_home":
+                return await self._distance_from_home(kwargs.get("name"))
+            else:
+                return f"Error: Unknown action '{action}'"
+        except aiohttp.ClientError as e:
+            return f"Error connecting to Home Assistant: {e}"
+        except TimeoutError:
+            return "Error: Home Assistant request timed out"
+        except Exception as e:
+            return f"Error: {e}"
+
+    async def _get_person_state(self, name: str) -> dict[str, Any] | str:
+        """Fetch a person entity's state. Returns dict on success, error string on failure."""
+        session = await self._get_session()
+        entity_id = f"person.{name}"
+        url = f"{self.base_url}/api/states/{entity_id}"
+        async with session.get(url) as resp:
+            if resp.status == 404:
+                return f"Person '{name}' not found. Use list_people to see available names."
+            if resp.status != 200:
+                return f"Error: HTTP {resp.status}"
+            return await resp.json()
+
+    async def _get_home_coords(self) -> tuple[float, float] | None:
+        """Get home zone coordinates, caching after first fetch."""
+        if self._home_coords is not None:
+            return self._home_coords
+
+        session = await self._get_session()
+        url = f"{self.base_url}/api/states/zone.home"
+        async with session.get(url) as resp:
+            if resp.status != 200:
+                return None
+            data = await resp.json()
+            attrs = data.get("attributes", {})
+            lat = attrs.get("latitude")
+            lon = attrs.get("longitude")
+            if lat is not None and lon is not None:
+                self._home_coords = (float(lat), float(lon))
+                return self._home_coords
+        return None
+
+    async def _locate(self, name: str | None) -> str:
+        """Get a person's current location details."""
+        if not name:
+            return "Error: 'name' is required for locate action."
+
+        data = await self._get_person_state(name)
+        if isinstance(data, str):
+            return data
+
+        attrs = data.get("attributes", {})
+        state = data.get("state", "unknown")
+        friendly_name = attrs.get("friendly_name", name.title())
+        lat = attrs.get("latitude")
+        lon = attrs.get("longitude")
+        gps_accuracy = attrs.get("gps_accuracy")
+
+        lines = [f"{friendly_name}: {state}"]
+        if lat is not None and lon is not None:
+            lines.append(f"  Coordinates: {lat:.6f}, {lon:.6f}")
+        if gps_accuracy is not None:
+            lines.append(f"  GPS accuracy: {gps_accuracy}m")
+        if source := attrs.get("source"):
+            lines.append(f"  Source: {source}")
+
+        return "\n".join(lines)
+
+    async def _is_home(self, name: str | None) -> str:
+        """Check whether a person is home."""
+        if not name:
+            return "Error: 'name' is required for is_home action."
+
+        data = await self._get_person_state(name)
+        if isinstance(data, str):
+            return data
+
+        state = data.get("state", "unknown")
+        friendly_name = data.get("attributes", {}).get("friendly_name", name.title())
+        is_home = state == "home"
+
+        if is_home:
+            return f"Yes, {friendly_name} is home."
+        else:
+            return f"No, {friendly_name} is not home (zone: {state})."
+
+    async def _list_people(self) -> str:
+        """List all tracked people with their home/away status."""
+        session = await self._get_session()
+        url = f"{self.base_url}/api/states"
+        async with session.get(url) as resp:
+            if resp.status != 200:
+                return f"Error: HTTP {resp.status}"
+
+            entities = await resp.json()
+            people = [
+                e for e in entities
+                if e.get("entity_id", "").startswith("person.")
+            ]
+
+            if not people:
+                return "No tracked people found in Home Assistant."
+
+            lines = [f"Tracked people ({len(people)}):"]
+            for person in sorted(people, key=lambda p: p.get("entity_id", "")):
+                friendly_name = person.get("attributes", {}).get("friendly_name", "?")
+                state = person.get("state", "unknown")
+                entity_id = person.get("entity_id", "")
+                person_name = entity_id.removeprefix("person.")
+                icon = "🏠" if state == "home" else "📍"
+                lines.append(f"  {icon} {friendly_name} ({person_name}): {state}")
+
+            return "\n".join(lines)
+
+    async def _distance_from_home(self, name: str | None) -> str:
+        """Calculate distance from home for a person."""
+        if not name:
+            return "Error: 'name' is required for distance_from_home action."
+
+        data = await self._get_person_state(name)
+        if isinstance(data, str):
+            return data
+
+        attrs = data.get("attributes", {})
+        state = data.get("state", "unknown")
+        friendly_name = attrs.get("friendly_name", name.title())
+        person_lat = attrs.get("latitude")
+        person_lon = attrs.get("longitude")
+
+        if person_lat is None or person_lon is None:
+            return f"Error: No GPS coordinates available for {friendly_name}."
+
+        home_coords = await self._get_home_coords()
+        if home_coords is None:
+            return "Error: Could not determine home location from zone.home entity."
+
+        distance = _haversine(home_coords[0], home_coords[1], float(person_lat), float(person_lon))
+
+        if distance < 0.1:
+            return f"{friendly_name} is at home."
+        elif distance < 1:
+            return f"{friendly_name} is {distance * 1000:.0f}m from home (zone: {state})."
+        else:
+            return f"{friendly_name} is {distance:.1f} km from home (zone: {state})."

--- a/nanobot/tools/test_phone_location.py
+++ b/nanobot/tools/test_phone_location.py
@@ -1,0 +1,335 @@
+"""Tests for Phone Location tool.
+
+Run with: pytest nanobot/tools/test_phone_location.py -v
+
+These tests use mocked responses - no real Home Assistant required.
+"""
+
+import pytest
+from unittest.mock import AsyncMock, patch
+
+from .phone_location import PhoneLocationTool, _haversine
+
+
+# Sample HA API responses
+PERSON_RON_HOME = {
+    "entity_id": "person.ron",
+    "state": "home",
+    "attributes": {
+        "friendly_name": "Ron",
+        "latitude": 51.5074,
+        "longitude": -0.1278,
+        "gps_accuracy": 10,
+        "source": "device_tracker.ron_phone",
+    },
+}
+
+PERSON_RON_AWAY = {
+    "entity_id": "person.ron",
+    "state": "work",
+    "attributes": {
+        "friendly_name": "Ron",
+        "latitude": 51.5155,
+        "longitude": -0.1419,
+        "gps_accuracy": 15,
+        "source": "device_tracker.ron_phone",
+    },
+}
+
+PERSON_ALICE_HOME = {
+    "entity_id": "person.alice",
+    "state": "home",
+    "attributes": {
+        "friendly_name": "Alice",
+        "latitude": 51.5074,
+        "longitude": -0.1278,
+        "gps_accuracy": 8,
+        "source": "device_tracker.alice_phone",
+    },
+}
+
+ZONE_HOME = {
+    "entity_id": "zone.home",
+    "state": "0",
+    "attributes": {
+        "latitude": 51.5074,
+        "longitude": -0.1278,
+        "radius": 100,
+        "friendly_name": "Home",
+    },
+}
+
+ALL_ENTITIES = [
+    PERSON_RON_HOME,
+    PERSON_ALICE_HOME,
+    {"entity_id": "light.kitchen", "state": "on", "attributes": {}},
+    {"entity_id": "switch.fan", "state": "off", "attributes": {}},
+]
+
+
+@pytest.fixture
+def tool():
+    """Create a tool instance with test config."""
+    return PhoneLocationTool(
+        base_url="http://homeassistant:8123",
+        token="test_token_123",
+    )
+
+
+class TestToolProperties:
+    """Test tool metadata."""
+
+    def test_name(self, tool):
+        assert tool.name == "phone_location"
+
+    def test_description(self, tool):
+        assert "phone location" in tool.description.lower()
+        assert "read-only" in tool.description.lower()
+
+    def test_parameters(self, tool):
+        params = tool.parameters
+        assert "action" in params["properties"]
+        actions = params["properties"]["action"]["enum"]
+        assert "locate" in actions
+        assert "is_home" in actions
+        assert "list_people" in actions
+        assert "distance_from_home" in actions
+        assert params["required"] == ["action"]
+
+    def test_to_schema(self, tool):
+        schema = tool.to_schema()
+        assert schema["type"] == "function"
+        assert schema["function"]["name"] == "phone_location"
+
+
+class TestMissingConfig:
+    """Test error handling when not configured."""
+
+    @pytest.mark.asyncio
+    async def test_missing_url(self):
+        tool = PhoneLocationTool(base_url="", token="")
+        result = await tool.execute(action="locate", name="ron")
+        assert "must be configured" in result
+
+    @pytest.mark.asyncio
+    async def test_missing_name_locate(self, tool):
+        result = await tool.execute(action="locate")
+        assert "'name' is required" in result
+
+    @pytest.mark.asyncio
+    async def test_missing_name_is_home(self, tool):
+        result = await tool.execute(action="is_home")
+        assert "'name' is required" in result
+
+    @pytest.mark.asyncio
+    async def test_missing_name_distance(self, tool):
+        result = await tool.execute(action="distance_from_home")
+        assert "'name' is required" in result
+
+    @pytest.mark.asyncio
+    async def test_unknown_action(self, tool):
+        result = await tool.execute(action="teleport")
+        assert "Unknown action" in result
+
+
+class TestLocate:
+    """Test the locate action."""
+
+    @pytest.mark.asyncio
+    async def test_locate_home(self, tool):
+        with patch("aiohttp.ClientSession") as mock_session:
+            mock_resp = AsyncMock()
+            mock_resp.status = 200
+            mock_resp.json = AsyncMock(return_value=PERSON_RON_HOME)
+            mock_session.return_value.get.return_value.__aenter__.return_value = mock_resp
+
+            result = await tool.execute(action="locate", name="ron")
+
+            assert "Ron" in result
+            assert "home" in result
+            assert "51.5074" in result
+            assert "GPS accuracy: 10m" in result
+
+    @pytest.mark.asyncio
+    async def test_locate_not_found(self, tool):
+        with patch("aiohttp.ClientSession") as mock_session:
+            mock_resp = AsyncMock()
+            mock_resp.status = 404
+            mock_session.return_value.get.return_value.__aenter__.return_value = mock_resp
+
+            result = await tool.execute(action="locate", name="nobody")
+
+            assert "not found" in result
+            assert "list_people" in result
+
+
+class TestIsHome:
+    """Test the is_home action."""
+
+    @pytest.mark.asyncio
+    async def test_is_home_yes(self, tool):
+        with patch("aiohttp.ClientSession") as mock_session:
+            mock_resp = AsyncMock()
+            mock_resp.status = 200
+            mock_resp.json = AsyncMock(return_value=PERSON_RON_HOME)
+            mock_session.return_value.get.return_value.__aenter__.return_value = mock_resp
+
+            result = await tool.execute(action="is_home", name="ron")
+
+            assert "Yes" in result
+            assert "Ron" in result
+            assert "is home" in result
+
+    @pytest.mark.asyncio
+    async def test_is_home_no(self, tool):
+        with patch("aiohttp.ClientSession") as mock_session:
+            mock_resp = AsyncMock()
+            mock_resp.status = 200
+            mock_resp.json = AsyncMock(return_value=PERSON_RON_AWAY)
+            mock_session.return_value.get.return_value.__aenter__.return_value = mock_resp
+
+            result = await tool.execute(action="is_home", name="ron")
+
+            assert "No" in result
+            assert "not home" in result
+            assert "work" in result
+
+
+class TestListPeople:
+    """Test the list_people action."""
+
+    @pytest.mark.asyncio
+    async def test_list_people(self, tool):
+        with patch("aiohttp.ClientSession") as mock_session:
+            mock_resp = AsyncMock()
+            mock_resp.status = 200
+            mock_resp.json = AsyncMock(return_value=ALL_ENTITIES)
+            mock_session.return_value.get.return_value.__aenter__.return_value = mock_resp
+
+            result = await tool.execute(action="list_people")
+
+            assert "Ron" in result
+            assert "Alice" in result
+            assert "2" in result  # count
+            # Should NOT include non-person entities
+            assert "kitchen" not in result
+            assert "fan" not in result
+
+    @pytest.mark.asyncio
+    async def test_list_people_empty(self, tool):
+        with patch("aiohttp.ClientSession") as mock_session:
+            mock_resp = AsyncMock()
+            mock_resp.status = 200
+            mock_resp.json = AsyncMock(return_value=[
+                {"entity_id": "light.kitchen", "state": "on", "attributes": {}},
+            ])
+            mock_session.return_value.get.return_value.__aenter__.return_value = mock_resp
+
+            result = await tool.execute(action="list_people")
+
+            assert "No tracked people" in result
+
+
+class TestDistanceFromHome:
+    """Test the distance_from_home action."""
+
+    @pytest.mark.asyncio
+    async def test_distance_at_home(self, tool):
+        """Person at home coords should report 'at home'."""
+        with patch("aiohttp.ClientSession") as mock_session:
+            mock_resp_person = AsyncMock()
+            mock_resp_person.status = 200
+            mock_resp_person.json = AsyncMock(return_value=PERSON_RON_HOME)
+
+            mock_resp_zone = AsyncMock()
+            mock_resp_zone.status = 200
+            mock_resp_zone.json = AsyncMock(return_value=ZONE_HOME)
+
+            # First call = person state, second call = zone.home
+            mock_session.return_value.get.return_value.__aenter__.side_effect = [
+                mock_resp_person, mock_resp_zone,
+            ]
+
+            result = await tool.execute(action="distance_from_home", name="ron")
+
+            assert "at home" in result
+
+    @pytest.mark.asyncio
+    async def test_distance_away(self, tool):
+        """Person at different coords should report distance."""
+        with patch("aiohttp.ClientSession") as mock_session:
+            mock_resp_person = AsyncMock()
+            mock_resp_person.status = 200
+            mock_resp_person.json = AsyncMock(return_value=PERSON_RON_AWAY)
+
+            mock_resp_zone = AsyncMock()
+            mock_resp_zone.status = 200
+            mock_resp_zone.json = AsyncMock(return_value=ZONE_HOME)
+
+            mock_session.return_value.get.return_value.__aenter__.side_effect = [
+                mock_resp_person, mock_resp_zone,
+            ]
+
+            result = await tool.execute(action="distance_from_home", name="ron")
+
+            assert "km from home" in result or "m from home" in result
+            assert "Ron" in result
+
+    @pytest.mark.asyncio
+    async def test_distance_no_gps(self, tool):
+        """Error when person has no GPS coordinates."""
+        person_no_gps = {
+            "entity_id": "person.ron",
+            "state": "unknown",
+            "attributes": {"friendly_name": "Ron"},
+        }
+
+        with patch("aiohttp.ClientSession") as mock_session:
+            mock_resp = AsyncMock()
+            mock_resp.status = 200
+            mock_resp.json = AsyncMock(return_value=person_no_gps)
+            mock_session.return_value.get.return_value.__aenter__.return_value = mock_resp
+
+            result = await tool.execute(action="distance_from_home", name="ron")
+
+            assert "No GPS coordinates" in result
+
+    @pytest.mark.asyncio
+    async def test_distance_no_home_zone(self, tool):
+        """Error when zone.home is not available."""
+        with patch("aiohttp.ClientSession") as mock_session:
+            mock_resp_person = AsyncMock()
+            mock_resp_person.status = 200
+            mock_resp_person.json = AsyncMock(return_value=PERSON_RON_AWAY)
+
+            mock_resp_zone = AsyncMock()
+            mock_resp_zone.status = 404
+
+            mock_session.return_value.get.return_value.__aenter__.side_effect = [
+                mock_resp_person, mock_resp_zone,
+            ]
+
+            result = await tool.execute(action="distance_from_home", name="ron")
+
+            assert "Could not determine home location" in result
+
+
+class TestHaversine:
+    """Test the Haversine distance formula directly."""
+
+    def test_same_point(self):
+        assert _haversine(51.5, -0.1, 51.5, -0.1) == 0.0
+
+    def test_known_distance(self):
+        # London (51.5074, -0.1278) to Paris (48.8566, 2.3522) ≈ 344 km
+        dist = _haversine(51.5074, -0.1278, 48.8566, 2.3522)
+        assert 340 < dist < 348
+
+    def test_short_distance(self):
+        # ~1 km apart
+        dist = _haversine(51.5074, -0.1278, 51.5164, -0.1278)
+        assert 0.9 < dist < 1.1
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary
- Adds `PhoneLocationTool` that queries Home Assistant `person.*` entities for household presence detection
- Supports 4 actions: `locate`, `is_home`, `list_people`, `distance_from_home`
- Uses Haversine formula for distance calculation against `zone.home` coordinates
- Strictly read-only — GET requests only, no location broadcasting
- Reuses existing HA config (`home_assistant_url` / `home_assistant_token`) — no new env vars needed

Closes #40

## Test plan
- [x] 22 new unit tests covering all actions, error handling, and Haversine math
- [x] Full tool suite (247 tests) passes with zero regressions
- [ ] Manual verification with live Home Assistant instance (requires HA + Companion App)