### PR TITLE
Add desktop sidebar navigation to PWA

### DIFF
--- a/app/src/components/layout/Layout.tsx
+++ b/app/src/components/layout/Layout.tsx
@@ -1,14 +1,18 @@
 import { Outlet } from 'react-router-dom'
 import Header from './Header'
 import BottomNav from './BottomNav'
+import Sidebar from './Sidebar'
 
 export default function Layout() {
   return (
     <div className="flex flex-col min-h-screen">
       <Header />
-      <main className="flex-1 overflow-y-auto pb-20 md:pb-0">
-        <Outlet />
-      </main>
+      <div className="flex flex-1 overflow-hidden">
+        <Sidebar />
+        <main className="flex-1 overflow-y-auto pb-20 md:pb-0">
+          <Outlet />
+        </main>
+      </div>
       <BottomNav />
     </div>
   )

--- a/app/src/components/layout/Sidebar.tsx
+++ b/app/src/components/layout/Sidebar.tsx
@@ -1,0 +1,67 @@
+import { NavLink } from 'react-router-dom'
+
+const navItems = [
+  { path: '/', label: 'Home', icon: HomeIcon },
+  { path: '/services', label: 'Services', icon: GridIcon },
+  { path: '/dashboard', label: 'Dashboard', icon: ChartIcon },
+  { path: '/settings', label: 'Settings', icon: CogIcon },
+]
+
+export default function Sidebar() {
+  return (
+    <aside className="hidden md:flex flex-col w-56 bg-butler-900 border-r border-butler-800 shrink-0">
+      <nav className="flex-1 p-3 space-y-1">
+        {navItems.map((item) => (
+          <NavLink
+            key={item.path}
+            to={item.path}
+            end={item.path === '/'}
+            className={({ isActive }) =>
+              `flex items-center gap-3 px-3 py-2.5 rounded-lg transition-colors ${
+                isActive
+                  ? 'bg-accent/10 text-accent'
+                  : 'text-butler-400 hover:text-butler-200 hover:bg-butler-800'
+              }`
+            }
+          >
+            <item.icon className="w-5 h-5" />
+            <span className="text-sm font-medium">{item.label}</span>
+          </NavLink>
+        ))}
+      </nav>
+    </aside>
+  )
+}
+
+function HomeIcon({ className }: { className?: string }) {
+  return (
+    <svg className={className} fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+      <path strokeLinecap="round" strokeLinejoin="round" d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6" />
+    </svg>
+  )
+}
+
+function GridIcon({ className }: { className?: string }) {
+  return (
+    <svg className={className} fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+      <path strokeLinecap="round" strokeLinejoin="round" d="M4 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2V6zM14 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2V6zM4 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2v-2zM14 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2v-2z" />
+    </svg>
+  )
+}
+
+function ChartIcon({ className }: { className?: string }) {
+  return (
+    <svg className={className} fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+      <path strokeLinecap="round" strokeLinejoin="round" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
+    </svg>
+  )
+}
+
+function CogIcon({ className }: { className?: string }) {
+  return (
+    <svg className={className} fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+      <path strokeLinecap="round" strokeLinejoin="round" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
+      <path strokeLinecap="round" strokeLinejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+    </svg>
+  )
+}


### PR DESCRIPTION
## Summary
- Adds a sidebar navigation component visible on desktop viewports (>= 768px)
- Integrates sidebar into the Layout alongside the existing mobile BottomNav
- Desktop users can now navigate between Home, Services, Dashboard, and Settings

Closes #85

## Changes
- **New:** `app/src/components/layout/Sidebar.tsx` — vertical nav with active state highlighting, matching the app's dark theme
- **Modified:** `app/src/components/layout/Layout.tsx` — wraps content in a flex row to accommodate the sidebar

## How it works
- **Mobile (<768px):** Bottom tab bar (unchanged)
- **Desktop (>=768px):** Left sidebar with labeled navigation links

## Test plan
- [ ] Open app in desktop browser — sidebar visible with all 4 nav links
- [ ] Click each nav link — correct page loads, active state highlighted
- [ ] Resize to mobile width — sidebar disappears, bottom nav appears
- [ ] Resize back to desktop — sidebar reappears
- [ ] Build passes (`npm run build`)