### PR TITLE
Fix embedding dimension mismatch and vector search (#74)

### DIFF
--- a/HOMESERVER_PLAN.md
+++ b/HOMESERVER_PLAN.md
@@ -495,7 +495,7 @@ CREATE TABLE butler.user_facts (
     source TEXT DEFAULT 'explicit',  -- 'explicit' (user said) or 'inferred'
     created_at TIMESTAMPTZ DEFAULT NOW(),
     last_referenced TIMESTAMPTZ,
-    embedding VECTOR(1536)  -- For semantic search (VectorChord/pgvector already installed)
+    embedding VECTOR(768)   -- nomic-embed-text via Ollama (see tools/embeddings.py)
 );
 
 -- Conversation history (short-term memory)

--- a/nanobot/migrations/001_butler_schema.sql
+++ b/nanobot/migrations/001_butler_schema.sql
@@ -24,7 +24,7 @@ CREATE TABLE IF NOT EXISTS butler.user_facts (
     category TEXT,                          -- preference, schedule, relationship, etc.
     confidence REAL DEFAULT 1.0,            -- How confident we are (0.0 - 1.0)
     source TEXT,                            -- Where we learned this (conversation, explicit, etc.)
-    embedding VECTOR(1536),                 -- For semantic search (optional)
+    embedding VECTOR(1536),                 -- For semantic search (migrated to 768 in 002)
     created_at TIMESTAMPTZ DEFAULT NOW(),
     expires_at TIMESTAMPTZ                  -- Optional expiry for temporary facts
 );

--- a/nanobot/tools/memory.py
+++ b/nanobot/tools/memory.py
@@ -26,7 +26,7 @@ import os
 import asyncpg
 
 from .base import Tool
-from .embeddings import EmbeddingService
+from .embeddings import EMBEDDING_DIM, EmbeddingService
 
 
 class DatabasePool:
@@ -197,6 +197,8 @@ class RememberFactTool(DatabaseTool):
         embedding = None
         if self._embedding_service:
             embedding = await self._embedding_service.embed(fact)
+            if embedding is not None and len(embedding) != EMBEDDING_DIM:
+                embedding = None  # dimension mismatch — skip vector storage
 
         if embedding is not None:
             # Store fact with vector embedding (cast text → vector for pgvector)


### PR DESCRIPTION
## Summary
- Add `EMBEDDING_DIM` and `EMBEDDING_MODEL` constants in `embeddings.py` as single source of truth for vector configuration
- Add dimension validation in both `EmbeddingService.embed()` and `RememberFactTool.execute()` (defense in depth)
- Add round-trip integration test verifying embed → store → search works end-to-end
- Add dimension mismatch test ensuring wrong-size vectors are rejected
- Document embedding model choice and how to change it in `nanobot/README.md`
- Update `HOMESERVER_PLAN.md` to reflect 768-dim (was 1536)

## Test plan
- [x] All 58 tests pass (56 existing + 2 new)
- [x] `test_embed_dimension_mismatch` — verifies 1536-dim vectors are rejected
- [x] `test_embed_store_search_round_trip` — verifies full semantic search pipeline
- [x] `test_wrong_dimension_embedding_not_stored` — verifies memory tool skips bad vectors

Closes #74