### PR TITLE
Connect PWA text chat to Butler API with SSE streaming

### DIFF
--- a/app/src/components/voice/TranscriptBubble.tsx
+++ b/app/src/components/voice/TranscriptBubble.tsx
@@ -22,7 +22,16 @@ export default function TranscriptBubble({ message, butlerName }: TranscriptBubb
         {!isUser && (
           <div className="text-xs text-butler-400 mb-1">{butlerName}</div>
         )}
-        <p className="text-sm">{message.content}</p>
+        {message.role === 'assistant' && !message.content && !message.toolStatus ? (
+          <p className="text-sm text-butler-400 animate-pulse">...</p>
+        ) : (
+          <p className="text-sm">{message.content}</p>
+        )}
+        {message.toolStatus && (
+          <p className="text-xs text-butler-400 italic mt-1 animate-pulse">
+            {message.toolStatus}
+          </p>
+        )}
         <div className={`text-xs mt-1 ${isUser ? 'text-blue-200' : 'text-butler-500'}`}>
           {formatTime(message.timestamp)}
           {message.type === 'voice' && ' • 🎤'}

--- a/app/src/hooks/useChatStream.ts
+++ b/app/src/hooks/useChatStream.ts
@@ -1,0 +1,125 @@
+import { useRef, useState, useCallback, useEffect } from 'react'
+import { useConversationStore } from '../stores/conversationStore'
+import { streamSSE } from '../services/sse'
+import type { ChatStreamEvent, Message } from '../types/conversation'
+
+const TOOL_LABELS: Record<string, string> = {
+  weather: 'Checking weather...',
+  home_assistant: 'Controlling smart home...',
+  list_ha_entities: 'Looking up devices...',
+  phone_location: 'Checking location...',
+  remember_fact: 'Remembering that...',
+  recall_facts: 'Recalling what I know...',
+  get_user: 'Looking up user info...',
+  radarr: 'Searching movies...',
+  sonarr: 'Searching TV shows...',
+  readarr: 'Searching books...',
+  jellyfin: 'Checking media library...',
+  immich: 'Searching photos...',
+  google_calendar: 'Checking calendar...',
+  gmail: 'Checking email...',
+  server_health: 'Checking server health...',
+  storage_monitor: 'Checking storage...',
+  whatsapp: 'Sending WhatsApp message...',
+}
+
+function getToolLabel(name: string): string {
+  return TOOL_LABELS[name] || `Using ${name.replace(/_/g, ' ')}...`
+}
+
+export interface UseChatStreamReturn {
+  sendMessage: (content: string) => void
+  cancelStream: () => void
+  isStreaming: boolean
+  error: string | null
+}
+
+export function useChatStream(): UseChatStreamReturn {
+  const { addMessage, updateMessage, setVoiceStatus } = useConversationStore()
+  const abortRef = useRef<AbortController | null>(null)
+  const [isStreaming, setIsStreaming] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const cancelStream = useCallback(() => {
+    abortRef.current?.abort()
+    abortRef.current = null
+    setIsStreaming(false)
+    setVoiceStatus('idle')
+  }, [setVoiceStatus])
+
+  // Abort on unmount
+  useEffect(() => () => { abortRef.current?.abort() }, [])
+
+  const sendMessage = useCallback((content: string) => {
+    // Abort any in-flight stream
+    abortRef.current?.abort()
+
+    setError(null)
+    setIsStreaming(true)
+    setVoiceStatus('processing')
+
+    const userMessage: Message = {
+      id: crypto.randomUUID(),
+      role: 'user',
+      content,
+      type: 'text',
+      timestamp: new Date().toISOString(),
+    }
+    addMessage(userMessage)
+
+    const assistantId = crypto.randomUUID()
+    const assistantMessage: Message = {
+      id: assistantId,
+      role: 'assistant',
+      content: '',
+      type: 'text',
+      timestamp: new Date().toISOString(),
+    }
+    addMessage(assistantMessage)
+
+    const controller = new AbortController()
+    abortRef.current = controller
+
+    let accumulated = ''
+
+    streamSSE<ChatStreamEvent>(
+      '/chat/stream',
+      { message: content },
+      {
+        onEvent(event) {
+          switch (event.type) {
+            case 'text_delta':
+              accumulated += event.delta
+              updateMessage(assistantId, { content: accumulated })
+              break
+            case 'tool_start':
+              updateMessage(assistantId, { toolStatus: getToolLabel(event.tool) })
+              break
+            case 'tool_end':
+              updateMessage(assistantId, { toolStatus: undefined })
+              break
+            case 'done':
+              break
+          }
+        },
+        onError(err) {
+          const msg = err.message || 'Something went wrong'
+          setError(msg)
+          // If we never got content, remove the empty placeholder
+          if (!accumulated) {
+            updateMessage(assistantId, { content: 'Failed to get a response.' })
+          }
+          setIsStreaming(false)
+          setVoiceStatus('idle')
+        },
+        onDone() {
+          setIsStreaming(false)
+          setVoiceStatus('idle')
+        },
+      },
+      controller.signal,
+    )
+  }, [addMessage, updateMessage, setVoiceStatus])
+
+  return { sendMessage, cancelStream, isStreaming, error }
+}

--- a/app/src/pages/Home.tsx
+++ b/app/src/pages/Home.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react'
+import { useEffect, useRef } from 'react'
 import { useUserStore } from '../stores/userStore'
 import { useConversationStore } from '../stores/conversationStore'
 import { useLiveKitVoice } from '../hooks/useLiveKitVoice'
@@ -20,6 +20,12 @@ export default function Home() {
 
   const butlerName = profile?.butlerName || 'Butler'
   const showWaveform = isRecording || voiceStatus === 'speaking'
+  const messagesEndRef = useRef<HTMLDivElement>(null)
+
+  // Auto-scroll to bottom when messages change (including streaming updates)
+  useEffect(() => {
+    messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' })
+  }, [messages])
 
   // Disconnect LiveKit when leaving the Home page
   useEffect(() => {
@@ -62,6 +68,7 @@ export default function Home() {
             />
           ))
         )}
+        <div ref={messagesEndRef} />
       </div>
 
       {/* Voice Interface */}

--- a/app/src/services/api.ts
+++ b/app/src/services/api.ts
@@ -12,7 +12,7 @@ class ApiError extends Error {
   }
 }
 
-async function getAuthToken(): Promise<string | null> {
+export async function getAuthToken(): Promise<string | null> {
   const authData = localStorage.getItem('butler-auth')
   if (!authData) return null
 

--- a/app/src/services/sse.ts
+++ b/app/src/services/sse.ts
@@ -1,0 +1,116 @@
+/**
+ * Generic SSE-over-POST utility.
+ *
+ * Uses fetch + ReadableStream (not EventSource) because we need:
+ *  - POST requests (to send the message body)
+ *  - Custom Authorization headers (for JWT auth)
+ */
+
+import { ApiError, getAuthToken } from './api'
+
+const API_BASE = import.meta.env.VITE_API_URL || 'http://localhost:8000/api'
+
+export interface SSECallbacks<T> {
+  onEvent: (event: T) => void
+  onError?: (error: Error) => void
+  onDone?: () => void
+}
+
+/**
+ * POST to an SSE endpoint and invoke callbacks for each parsed event.
+ *
+ * SSE format expected:
+ *   data: {"type":"text_delta","delta":"hi"}\n\n
+ *   data: [DONE]\n\n
+ */
+export async function streamSSE<T>(
+  endpoint: string,
+  body: unknown,
+  callbacks: SSECallbacks<T>,
+  signal?: AbortSignal,
+): Promise<void> {
+  const token = await getAuthToken()
+
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+  }
+  if (token) {
+    headers['Authorization'] = `Bearer ${token}`
+  }
+
+  let response: Response
+  try {
+    response = await fetch(`${API_BASE}${endpoint}`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify(body),
+      signal,
+    })
+  } catch (err: unknown) {
+    if (err instanceof DOMException && err.name === 'AbortError') {
+      callbacks.onDone?.()
+      return
+    }
+    callbacks.onError?.(err instanceof Error ? err : new Error(String(err)))
+    return
+  }
+
+  if (!response.ok) {
+    const errBody = await response.json().catch(() => ({
+      message: `HTTP ${response.status}: Request failed`,
+    }))
+    callbacks.onError?.(new ApiError(response.status, errBody.message || `HTTP ${response.status}`))
+    return
+  }
+
+  const reader = response.body?.getReader()
+  if (!reader) {
+    callbacks.onError?.(new Error('Response body is not readable'))
+    return
+  }
+
+  const decoder = new TextDecoder()
+  let buffer = ''
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read()
+      if (done) break
+
+      buffer += decoder.decode(value, { stream: true })
+
+      // Split on double-newline (SSE event boundary)
+      const parts = buffer.split('\n\n')
+      // Keep the last (potentially incomplete) part in the buffer
+      buffer = parts.pop() || ''
+
+      for (const part of parts) {
+        const line = part.trim()
+        if (!line.startsWith('data: ')) continue
+
+        const payload = line.slice(6) // strip "data: "
+        if (payload === '[DONE]') {
+          callbacks.onDone?.()
+          return
+        }
+
+        try {
+          callbacks.onEvent(JSON.parse(payload) as T)
+        } catch {
+          // Skip malformed JSON lines
+        }
+      }
+    }
+  } catch (err: unknown) {
+    if (err instanceof DOMException && err.name === 'AbortError') {
+      callbacks.onDone?.()
+      return
+    }
+    callbacks.onError?.(err instanceof Error ? err : new Error(String(err)))
+  } finally {
+    reader.releaseLock()
+  }
+
+  // If we exit the loop without [DONE], still signal completion
+  callbacks.onDone?.()
+}

--- a/app/src/stores/conversationStore.ts
+++ b/app/src/stores/conversationStore.ts
@@ -15,6 +15,7 @@ interface ConversationState {
 
   // Actions
   addMessage: (message: Message) => void
+  updateMessage: (id: string, updates: Partial<Pick<Message, 'content' | 'toolStatus'>>) => void
   setMessages: (messages: Message[]) => void
   clearMessages: () => void
   setConnectionStatus: (status: ConnectionStatus) => void
@@ -30,6 +31,12 @@ export const useConversationStore = create<ConversationState>((set) => ({
 
   addMessage: (message) => set((state) => ({
     messages: [...state.messages, message],
+  })),
+
+  updateMessage: (id, updates) => set((state) => ({
+    messages: state.messages.map((m) =>
+      m.id === id ? { ...m, ...updates } : m
+    ),
   })),
 
   setMessages: (messages) => set({ messages }),

--- a/app/src/types/conversation.ts
+++ b/app/src/types/conversation.ts
@@ -7,6 +7,7 @@ export interface Message {
   content: string
   type: MessageType
   timestamp: string
+  toolStatus?: string
 }
 
 export interface Conversation {
@@ -32,3 +33,10 @@ export interface AgentStateMessage {
 }
 
 export type LiveKitDataMessage = TranscriptMessage | AgentStateMessage
+
+/** SSE events from POST /api/chat/stream */
+export type ChatStreamEvent =
+  | { type: 'text_delta'; delta: string }
+  | { type: 'tool_start'; tool: string }
+  | { type: 'tool_end'; tool: string }
+  | { type: 'done'; message_id: string }

--- a/nanobot/api/routes/chat.py
+++ b/nanobot/api/routes/chat.py
@@ -7,16 +7,20 @@ Same pipeline as voice but with 'pwa' channel tag.
 from __future__ import annotations
 
 import json
+import logging
 import uuid
 
 from fastapi import APIRouter, Depends
+from starlette.responses import StreamingResponse
 
 from tools import DatabasePool, Tool
 
 from ..context import load_user_context
 from ..deps import get_current_user, get_db_pool, get_tools, get_user_tools
-from ..llm import chat_with_tools
+from ..llm import chat_with_tools, stream_chat_with_events
 from ..models import ChatRequest, ChatResponse
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
@@ -66,3 +70,75 @@ async def text_chat(
     )
 
     return ChatResponse(response=response_text, message_id=message_id)
+
+
+@router.post("/chat/stream")
+async def stream_text_chat(
+    req: ChatRequest,
+    user_id: str = Depends(get_current_user),
+    pool: DatabasePool = Depends(get_db_pool),
+    tools: dict[str, Tool] = Depends(get_tools),
+):
+    """Stream a text chat response as Server-Sent Events.
+
+    Same pipeline as ``text_chat`` but returns SSE so the PWA can render
+    text as it arrives and show tool-use activity.
+
+    SSE format::
+
+        data: {"type":"text_delta","delta":"Hello"}
+        data: {"type":"tool_start","tool":"weather"}
+        data: {"type":"tool_end","tool":"weather"}
+        data: {"type":"text_delta","delta":"It's sunny."}
+        data: {"type":"done","message_id":"<uuid>"}
+        data: [DONE]
+    """
+    ctx = await load_user_context(pool, user_id)
+    all_tools = get_user_tools(user_id, tools, pool)
+    message_id = str(uuid.uuid4())
+    full_response_parts: list[str] = []
+
+    async def generate():
+        try:
+            async for event in stream_chat_with_events(
+                system_prompt=ctx.system_prompt,
+                user_message=req.message,
+                tools=all_tools,
+            ):
+                if event.get("type") == "text_delta":
+                    full_response_parts.append(event["delta"])
+                yield f"data: {json.dumps(event)}\n\n"
+
+            yield f"data: {json.dumps({'type': 'done', 'message_id': message_id})}\n\n"
+            yield "data: [DONE]\n\n"
+        finally:
+            full_text = "".join(full_response_parts)
+            if full_text:
+                try:
+                    db = pool.pool
+                    await db.execute(
+                        """
+                        INSERT INTO butler.conversation_history
+                            (user_id, channel, role, content)
+                        VALUES ($1, 'pwa', 'user', $2)
+                        """,
+                        user_id,
+                        req.message,
+                    )
+                    await db.execute(
+                        """
+                        INSERT INTO butler.conversation_history
+                            (user_id, channel, role, content, metadata)
+                        VALUES ($1, 'pwa', 'assistant', $2, $3::jsonb)
+                        """,
+                        user_id,
+                        full_text,
+                        json.dumps({"message_id": message_id}),
+                    )
+                except Exception:
+                    logger.exception(
+                        "Failed to save chat conversation history for user=%s",
+                        user_id,
+                    )
+
+    return StreamingResponse(generate(), media_type="text/event-stream")


### PR DESCRIPTION
## Summary
Replace mock setTimeout logic in ChatInput with real streaming API calls to POST /api/chat/stream. Backend emits structured SSE events (text_delta, tool_start, tool_end) for real-time UI updates. Frontend uses fetch + ReadableStream for authorization, AbortController for cancellation.

## Changes
- Backend: New `stream_chat_with_events()` in llm.py, new `/chat/stream` SSE endpoint
- Frontend: New `useChatStream` hook, `sse.ts` utility, store updates for streaming
- UI: Text streams word-by-word, tool status shows during execution, auto-scroll on updates

## Test Plan
- Type a message, verify text streams character-by-character
- Ask "what's the weather?" to test tool-use indicators
- Send a message, quickly send another to test abort behavior
- Verify error messages appear if backend is unavailable

Closes #67