### PR TITLE
Add real service status checks to Services page

### DIFF
--- a/app/.env.example
+++ b/app/.env.example
@@ -1,2 +1,12 @@
 VITE_API_URL=http://localhost:8000/api
 VITE_LIVEKIT_URL=ws://localhost:7880
+
+# Service URLs — set VITE_SERVICE_HOSTNAME for Tailscale/remote access,
+# or override individual services with VITE_<SERVICE>_URL.
+# VITE_SERVICE_HOSTNAME=macmini.tail12345.ts.net
+# VITE_JELLYFIN_URL=http://jellyfin.local:8096
+# VITE_AUDIOBOOKSHELF_URL=http://audiobooks.local:13378
+# VITE_CALIBRE_URL=http://books.local:8083
+# VITE_IMMICH_URL=http://photos.local:2283
+# VITE_NEXTCLOUD_URL=http://files.local
+# VITE_HOMEASSISTANT_URL=http://ha.local:8123

--- a/app/src/components/services/ServiceCard.tsx
+++ b/app/src/components/services/ServiceCard.tsx
@@ -14,7 +14,9 @@ export default function ServiceCard({ service }: ServiceCardProps) {
   return (
     <button
       onClick={handleClick}
-      className="card p-4 text-left hover:bg-butler-700/50 transition-colors group"
+      className={`card p-4 text-left hover:bg-butler-700/50 transition-colors group${
+        service.status === 'offline' ? ' opacity-60 border-red-500/20' : ''
+      }`}
     >
       <div className="text-3xl mb-2">{service.icon}</div>
       <h3 className="font-medium text-butler-100 group-hover:text-accent transition-colors">

--- a/app/src/config/services.ts
+++ b/app/src/config/services.ts
@@ -1,0 +1,113 @@
+import type { Service, ServiceCategory } from '../types/services'
+import type { ServiceStatus } from '../services/api'
+
+/**
+ * Maps backend health-check service names to frontend service IDs.
+ * Only user-facing services are included — infrastructure services
+ * (radarr, sonarr, prowlarr, etc.) are shown on the Dashboard instead.
+ */
+const SERVICE_NAME_MAP: Record<string, string> = {
+  'jellyfin': 'jellyfin',
+  'audiobookshelf': 'audiobookshelf',
+  'calibre-web': 'calibre',
+  'immich-server': 'immich',
+  'nextcloud': 'nextcloud',
+  'homeassistant': 'home-assistant',
+}
+
+// Optional: set VITE_SERVICE_HOSTNAME for Tailscale/remote access
+// e.g. VITE_SERVICE_HOSTNAME=macmini.tail12345.ts.net
+const HOSTNAME = import.meta.env.VITE_SERVICE_HOSTNAME || ''
+
+function serviceUrl(envVar: string, port: number, localDefault: string): string {
+  const explicit = import.meta.env[envVar]
+  if (explicit) return explicit
+  if (HOSTNAME) return `http://${HOSTNAME}:${port}`
+  return localDefault
+}
+
+export const services: Service[] = [
+  {
+    id: 'jellyfin',
+    name: 'Jellyfin',
+    description: 'Movies & TV Shows',
+    icon: '🎬',
+    url: serviceUrl('VITE_JELLYFIN_URL', 8096, 'http://jellyfin.local'),
+    mobileUrl: 'jellyfin://',
+    category: 'media',
+  },
+  {
+    id: 'audiobookshelf',
+    name: 'Audiobookshelf',
+    description: 'Audiobooks & Podcasts',
+    icon: '🎧',
+    url: serviceUrl('VITE_AUDIOBOOKSHELF_URL', 13378, 'http://audiobooks.local'),
+    mobileUrl: 'audiobookshelf://',
+    category: 'media',
+  },
+  {
+    id: 'calibre',
+    name: 'Calibre-Web',
+    description: 'E-Books Library',
+    icon: '📚',
+    url: serviceUrl('VITE_CALIBRE_URL', 8083, 'http://books.local'),
+    category: 'books',
+  },
+  {
+    id: 'immich',
+    name: 'Immich',
+    description: 'Photo Backup',
+    icon: '📷',
+    url: serviceUrl('VITE_IMMICH_URL', 2283, 'http://photos.local'),
+    mobileUrl: 'immich://',
+    category: 'photos',
+  },
+  {
+    id: 'nextcloud',
+    name: 'Nextcloud',
+    description: 'Files & Documents',
+    icon: '📁',
+    url: serviceUrl('VITE_NEXTCLOUD_URL', 80, 'http://files.local'),
+    mobileUrl: 'nextcloud://',
+    category: 'files',
+  },
+  {
+    id: 'home-assistant',
+    name: 'Home Assistant',
+    description: 'Smart Home Control',
+    icon: '🏠',
+    url: serviceUrl('VITE_HOMEASSISTANT_URL', 8123, 'http://ha.local'),
+    mobileUrl: 'homeassistant://',
+    category: 'smart-home',
+  },
+]
+
+export const categoryLabels: Record<ServiceCategory, string> = {
+  'media': 'Media',
+  'books': 'Books',
+  'photos': 'Photos',
+  'files': 'Files',
+  'smart-home': 'Smart Home',
+}
+
+/**
+ * Merge backend health status onto the frontend service list.
+ * Services not found in the health response get status 'unknown'.
+ */
+export function applyHealthStatus(
+  frontendServices: Service[],
+  healthServices: ServiceStatus[],
+): Service[] {
+  const statusByFrontendId = new Map<string, 'online' | 'offline'>()
+  for (const svc of healthServices) {
+    const frontendId = SERVICE_NAME_MAP[svc.name]
+    if (frontendId) {
+      statusByFrontendId.set(frontendId, svc.status)
+    }
+  }
+
+  return frontendServices.map(s => ({
+    ...s,
+    status: statusByFrontendId.get(s.id) ?? 'unknown',
+  }))
+}


### PR DESCRIPTION
## Summary
Wires the existing `/api/system/health` endpoint to the Services page so service cards show live online/offline status. Services are fetched on mount and auto-refresh every 60 seconds.

## Changes
- **New:** `app/src/config/services.ts` — Service definitions, backend→frontend name mapping, env-based URL resolution with 3-tier fallback (per-service env var → shared hostname → .local default)
- **Updated:** `Services.tsx` — Add health data fetching with 60s auto-refresh, wire status onto cards
- **Updated:** `ServiceCard.tsx` — Add dimmed appearance with red border for offline services
- **Updated:** `.env.example` — Document service URL configuration options

## How It Works
1. Page mount triggers `fetchStatus()` → calls `/api/system/health`
2. Backend probes all services, returns `{services: [{name, status, ...}]}`
3. `applyHealthStatus()` maps backend names to frontend IDs (e.g., `immich-server` → `immich`)
4. Service cards render with green/red/gray status dots
5. `setInterval` repeats fetch every 60 seconds
6. Error banner appears if fetch fails, but cards stay usable for navigation

## Tailscale Support
Users on Tailscale can set `VITE_SERVICE_HOSTNAME=macmini.tail12345.ts.net` once to fix all URLs. LAN users get `.local` defaults.

Closes #71