### PR TITLE
Add per-user tool permission system

### DIFF
--- a/app/src/types/user.ts
+++ b/app/src/types/user.ts
@@ -1,11 +1,21 @@
 export type UserRole = 'admin' | 'user'
 
+export type ToolPermission =
+  | 'media'
+  | 'home'
+  | 'location'
+  | 'calendar'
+  | 'email'
+  | 'automation'
+  | 'communication'
+
 export interface User {
   id: string
   name: string
   email?: string
   butlerName: string
   role: UserRole
+  permissions: ToolPermission[]
   createdAt: string
 }
 
@@ -50,4 +60,21 @@ export interface OAuthConnection {
   connected: boolean
   accountId?: string
   connectedAt?: string
+}
+
+export interface AdminUser {
+  id: string
+  name: string
+  role: UserRole
+  permissions: ToolPermission[]
+}
+
+export const PERMISSION_INFO: Record<ToolPermission, { label: string; description: string }> = {
+  media: { label: 'Media', description: 'Radarr, Sonarr, Readarr, Immich, Jellyfin' },
+  home: { label: 'Smart Home', description: 'Home Assistant, entity control' },
+  location: { label: 'Location', description: 'Phone location tracking' },
+  calendar: { label: 'Calendar', description: 'Google Calendar' },
+  email: { label: 'Email', description: 'Gmail' },
+  automation: { label: 'Automation', description: 'Scheduled tasks' },
+  communication: { label: 'Communication', description: 'WhatsApp messages' },
 }

--- a/nanobot/api/models.py
+++ b/nanobot/api/models.py
@@ -68,6 +68,24 @@ class CreateInviteCodeResponse(BaseModel):
     expiresAt: str
 
 
+# --- Admin: User & Permission Management ---
+
+
+class AdminUserInfo(BaseModel):
+    id: str
+    name: str
+    role: str
+    permissions: list[str]
+
+
+class AdminUserListResponse(BaseModel):
+    users: list[AdminUserInfo]
+
+
+class UpdatePermissionsRequest(BaseModel):
+    permissions: list[str]
+
+
 # --- User (matches app/src/types/user.ts) ---
 
 
@@ -91,6 +109,7 @@ class UserProfile(BaseModel):
     email: str | None = None
     butlerName: str = "Butler"
     role: str = "user"
+    permissions: list[str] = Field(default_factory=lambda: ["media", "home"])
     createdAt: str
     soul: SoulConfig = Field(default_factory=SoulConfig)
     facts: list[UserFact] = Field(default_factory=list)

--- a/nanobot/api/routes/chat.py
+++ b/nanobot/api/routes/chat.py
@@ -41,7 +41,7 @@ async def text_chat(
     track the response.
     """
     ctx = await load_user_context(pool, user_id)
-    all_tools = get_user_tools(user_id, tools, pool)
+    all_tools = await get_user_tools(user_id, tools, pool)
 
     response_text = await chat_with_tools(
         system_prompt=ctx.system_prompt,
@@ -144,7 +144,7 @@ async def stream_text_chat(
         data: [DONE]
     """
     ctx = await load_user_context(pool, user_id)
-    all_tools = get_user_tools(user_id, tools, pool)
+    all_tools = await get_user_tools(user_id, tools, pool)
     message_id = str(uuid.uuid4())
     full_response_parts: list[str] = []
 

--- a/nanobot/api/routes/voice.py
+++ b/nanobot/api/routes/voice.py
@@ -51,7 +51,7 @@ async def process_voice(
     user_id = caller_user_id or req.user_id
 
     ctx = await load_user_context(pool, user_id)
-    all_tools = get_user_tools(user_id, tools, pool)
+    all_tools = await get_user_tools(user_id, tools, pool)
 
     response_text = await chat_with_tools(
         system_prompt=ctx.system_prompt,
@@ -110,7 +110,7 @@ async def stream_voice(
     """
     user_id = caller_user_id or req.user_id
     ctx = await load_user_context(pool, user_id)
-    all_tools = get_user_tools(user_id, tools, pool)
+    all_tools = await get_user_tools(user_id, tools, pool)
     full_response_parts: list[str] = []
 
     async def generate():

--- a/nanobot/migrations/005_user_permissions.sql
+++ b/nanobot/migrations/005_user_permissions.sql
@@ -1,0 +1,6 @@
+-- Add per-user tool permissions
+-- Each user gets a JSONB array of permission group names that controls
+-- which tools the LLM can use on their behalf.
+
+ALTER TABLE butler.users
+    ADD COLUMN IF NOT EXISTS permissions JSONB NOT NULL DEFAULT '["media", "home"]';


### PR DESCRIPTION
Implements #79 — adds granular per-user permission control for tools.

**Key changes:**
- Admins can now restrict which tools each user can access (media, home, location, calendar, email, automation, communication)
- Tools are filtered at the API layer in `get_user_tools()` before reaching Claude
- Always-allowed tools (memory, weather, monitoring) bypass permissions
- Settings UI: users see read-only badges, admins get a management interface with toggles

**Technical details:**
- New `permissions` JSONB column in `butler.users` (default: `["media", "home"]`)
- Admin endpoints: `GET /admin/users`, `PUT /admin/users/{id}/permissions`
- Fixed empty-list handling bug (empty `[]` is now respected, not replaced with defaults)