### PR TITLE
Add PWA push notifications via Web Push API

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -30,6 +30,7 @@
         "typescript": "^5.6.3",
         "vite": "^5.4.10",
         "vite-plugin-pwa": "^0.20.5",
+        "workbox-precaching": "^7.4.0",
         "workbox-window": "^7.1.0"
       }
     },

--- a/app/package.json
+++ b/app/package.json
@@ -32,6 +32,7 @@
     "typescript": "^5.6.3",
     "vite": "^5.4.10",
     "vite-plugin-pwa": "^0.20.5",
+    "workbox-precaching": "^7.4.0",
     "workbox-window": "^7.1.0"
   }
 }

--- a/app/src/hooks/usePushNotifications.ts
+++ b/app/src/hooks/usePushNotifications.ts
@@ -1,0 +1,143 @@
+import { useCallback, useEffect, useState } from 'react'
+import { api } from '../services/api'
+
+interface VapidKeyResponse {
+  vapidPublicKey: string
+}
+
+/**
+ * Convert a base64url-encoded VAPID key to a Uint8Array for PushManager.subscribe().
+ */
+function urlBase64ToUint8Array(base64String: string): Uint8Array {
+  const padding = '='.repeat((4 - (base64String.length % 4)) % 4)
+  const base64 = (base64String + padding).replace(/-/g, '+').replace(/_/g, '/')
+  const raw = atob(base64)
+  const arr = new Uint8Array(raw.length)
+  for (let i = 0; i < raw.length; i++) {
+    arr[i] = raw.charCodeAt(i)
+  }
+  return arr
+}
+
+interface UsePushNotificationsReturn {
+  isSupported: boolean
+  permission: NotificationPermission
+  isSubscribed: boolean
+  isLoading: boolean
+  subscribe: () => Promise<void>
+  unsubscribe: () => Promise<void>
+  sendTest: () => Promise<void>
+}
+
+export function usePushNotifications(): UsePushNotificationsReturn {
+  const isSupported = 'Notification' in window && 'PushManager' in window && 'serviceWorker' in navigator
+  const [permission, setPermission] = useState<NotificationPermission>(
+    isSupported ? Notification.permission : 'denied'
+  )
+  const [isSubscribed, setIsSubscribed] = useState(false)
+  const [isLoading, setIsLoading] = useState(true)
+
+  // Check existing subscription on mount
+  useEffect(() => {
+    if (!isSupported) {
+      setIsLoading(false)
+      return
+    }
+
+    navigator.serviceWorker.ready.then(async (reg) => {
+      const sub = await reg.pushManager.getSubscription()
+      setIsSubscribed(!!sub)
+      setPermission(Notification.permission)
+      setIsLoading(false)
+    }).catch(() => {
+      setIsLoading(false)
+    })
+  }, [isSupported])
+
+  const subscribe = useCallback(async () => {
+    if (!isSupported) return
+    setIsLoading(true)
+
+    try {
+      // Request notification permission
+      const perm = await Notification.requestPermission()
+      setPermission(perm)
+      if (perm !== 'granted') {
+        setIsLoading(false)
+        return
+      }
+
+      // Get VAPID public key from backend
+      const { vapidPublicKey } = await api.get<VapidKeyResponse>('/push/vapid-key')
+      if (!vapidPublicKey) {
+        console.warn('Push notifications not configured: no VAPID key')
+        setIsLoading(false)
+        return
+      }
+
+      // Subscribe via PushManager
+      const reg = await navigator.serviceWorker.ready
+      const sub = await reg.pushManager.subscribe({
+        userVisibleOnly: true,
+        applicationServerKey: urlBase64ToUint8Array(vapidPublicKey).buffer as ArrayBuffer,
+      })
+
+      // Send subscription to backend
+      const key = sub.getKey('p256dh')
+      const auth = sub.getKey('auth')
+      if (!key || !auth) throw new Error('Missing subscription keys')
+
+      await api.post('/push/subscribe', {
+        endpoint: sub.endpoint,
+        keys: {
+          p256dh: btoa(String.fromCharCode(...new Uint8Array(key))),
+          auth: btoa(String.fromCharCode(...new Uint8Array(auth))),
+        },
+      })
+
+      setIsSubscribed(true)
+    } catch (err) {
+      console.error('Push subscription failed:', err)
+    } finally {
+      setIsLoading(false)
+    }
+  }, [isSupported])
+
+  const unsubscribe = useCallback(async () => {
+    if (!isSupported) return
+    setIsLoading(true)
+
+    try {
+      const reg = await navigator.serviceWorker.ready
+      const sub = await reg.pushManager.getSubscription()
+
+      if (sub) {
+        // Remove from backend first (endpoint as query param)
+        await api.delete(`/push/subscribe?endpoint=${encodeURIComponent(sub.endpoint)}`)
+
+        // Unsubscribe from browser
+        await sub.unsubscribe()
+      }
+
+      setIsSubscribed(false)
+    } catch (err) {
+      console.error('Push unsubscription failed:', err)
+    } finally {
+      setIsLoading(false)
+    }
+  }, [isSupported])
+
+  const sendTest = useCallback(async () => {
+    await api.post('/push/test')
+  }, [])
+
+  return {
+    isSupported,
+    permission,
+    isSubscribed,
+    isLoading,
+    subscribe,
+    unsubscribe,
+    sendTest,
+  }
+}

--- a/app/src/pages/Settings.tsx
+++ b/app/src/pages/Settings.tsx
@@ -3,6 +3,7 @@ import { useAuthStore } from '../stores/authStore'
 import { useUserStore } from '../stores/userStore'
 import { useSettingsStore } from '../stores/settingsStore'
 import { useConversationStore } from '../stores/conversationStore'
+import { usePushNotifications } from '../hooks/usePushNotifications'
 import { api, clearUserFacts, deleteUserAccount } from '../services/api'
 import ConfirmDialog from '../components/ConfirmDialog'
 import type { AdminUser, InviteCode, OAuthConnection, ToolPermission } from '../types/user'
@@ -34,6 +35,7 @@ export default function Settings() {
   const { profile, updateButlerName, updateSoul, clearAllFacts, clearProfile, isLoading } = useUserStore()
   const { voiceMode, setVoiceMode } = useSettingsStore()
   const { clearMessages } = useConversationStore()
+  const push = usePushNotifications()
   const isAdmin = role === 'admin'
 
   const [connections, setConnections] = useState<OAuthConnection[]>([])
@@ -595,6 +597,63 @@ export default function Settings() {
             This setting only applies to this device.
           </p>
         </div>
+      </section>
+
+      {/* Push Notifications - per device */}
+      <section className="card p-4">
+        <h2 className="text-sm font-medium text-butler-400 uppercase tracking-wide mb-4">
+          Push Notifications
+          <span className="text-butler-600 ml-2 text-xs normal-case">this device</span>
+        </h2>
+
+        {!push.isSupported ? (
+          <p className="text-sm text-butler-500">
+            Push notifications are not supported in this browser.
+          </p>
+        ) : push.permission === 'denied' ? (
+          <p className="text-sm text-butler-500">
+            Notifications are blocked. Enable them in your browser settings to receive push notifications.
+          </p>
+        ) : (
+          <div className="space-y-3">
+            <div className="flex items-center justify-between">
+              <div>
+                <div className="text-sm text-butler-100">
+                  {push.isSubscribed ? 'Enabled' : 'Disabled'}
+                </div>
+                <div className="text-xs text-butler-500">
+                  {push.isSubscribed
+                    ? 'You will receive notifications from Butler'
+                    : 'Enable to receive alerts when the app is closed'}
+                </div>
+              </div>
+              <button
+                onClick={push.isSubscribed ? push.unsubscribe : push.subscribe}
+                disabled={push.isLoading}
+                className={`px-3 py-1.5 rounded-lg text-xs disabled:opacity-50 ${
+                  push.isSubscribed
+                    ? 'bg-red-900/50 text-red-300 hover:bg-red-900 hover:text-red-200'
+                    : 'bg-accent text-white hover:bg-accent/80'
+                }`}
+              >
+                {push.isLoading
+                  ? 'Loading...'
+                  : push.isSubscribed
+                    ? 'Disable'
+                    : 'Enable'}
+              </button>
+            </div>
+
+            {push.isSubscribed && (
+              <button
+                onClick={push.sendTest}
+                className="w-full btn bg-butler-700 text-butler-300 hover:bg-butler-600 text-sm"
+              >
+                Send Test Notification
+              </button>
+            )}
+          </div>
+        )}
       </section>
 
       {/* Data Management */}

--- a/app/src/sw.ts
+++ b/app/src/sw.ts
@@ -1,0 +1,58 @@
+/// <reference lib="webworker" />
+
+import { cleanupOutdatedCaches, precacheAndRoute } from 'workbox-precaching'
+
+declare let self: ServiceWorkerGlobalScope
+
+// Workbox injects the precache manifest here during build
+precacheAndRoute(self.__WB_MANIFEST)
+cleanupOutdatedCaches()
+
+// ── Push notification handling ───────────────────────────────────────
+
+interface PushPayload {
+  title: string
+  body: string
+  url?: string
+  category?: string
+}
+
+self.addEventListener('push', (event) => {
+  if (!event.data) return
+
+  let payload: PushPayload
+  try {
+    payload = event.data.json() as PushPayload
+  } catch {
+    payload = { title: 'Butler', body: event.data.text() }
+  }
+
+  const options: NotificationOptions = {
+    body: payload.body,
+    icon: '/icons/icon-192.png',
+    badge: '/icons/icon-192.png',
+    tag: payload.category || 'general',
+    data: { url: payload.url || '/' },
+  }
+
+  event.waitUntil(self.registration.showNotification(payload.title, options))
+})
+
+self.addEventListener('notificationclick', (event) => {
+  event.notification.close()
+
+  const url = (event.notification.data?.url as string) || '/'
+
+  // Focus an existing window or open a new one
+  event.waitUntil(
+    self.clients.matchAll({ type: 'window', includeUncontrolled: true }).then((clients) => {
+      for (const client of clients) {
+        if (client.url.includes(self.location.origin) && 'focus' in client) {
+          client.navigate(url)
+          return client.focus()
+        }
+      }
+      return self.clients.openWindow(url)
+    })
+  )
+})

--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -6,6 +6,9 @@ export default defineConfig({
   plugins: [
     react(),
     VitePWA({
+      strategies: 'injectManifest',
+      srcDir: 'src',
+      filename: 'sw.ts',
       registerType: 'autoUpdate',
       includeAssets: ['icons/*.png'],
       manifest: {
@@ -37,21 +40,8 @@ export default defineConfig({
           }
         ]
       },
-      workbox: {
-        globPatterns: ['**/*.{js,css,html,ico,png,svg,woff2}'],
-        runtimeCaching: [
-          {
-            urlPattern: /^https:\/\/api\./i,
-            handler: 'NetworkFirst',
-            options: {
-              cacheName: 'api-cache',
-              expiration: {
-                maxEntries: 50,
-                maxAgeSeconds: 60 * 60 // 1 hour
-              }
-            }
-          }
-        ]
+      injectManifest: {
+        globPatterns: ['**/*.{js,css,html,ico,png,svg,woff2}']
       }
     })
   ],

--- a/nanobot/api/config.py
+++ b/nanobot/api/config.py
@@ -89,6 +89,11 @@ class Settings(BaseSettings):
     # Home Assistant webhook authentication
     ha_webhook_secret: str = ""
 
+    # Web Push (VAPID keys for PWA push notifications)
+    vapid_public_key: str = ""
+    vapid_private_key: str = ""
+    vapid_subject: str = "mailto:admin@homeserver.local"
+
     model_config = {"env_file": ".env", "env_file_encoding": "utf-8"}
 
 

--- a/nanobot/api/models.py
+++ b/nanobot/api/models.py
@@ -231,6 +231,25 @@ class ScheduledTaskResponse(BaseModel):
     createdAt: str  # ISO8601
 
 
+# --- Push Notifications ---
+
+
+class PushSubscriptionKeys(BaseModel):
+    p256dh: str
+    auth: str
+
+
+class PushSubscribeRequest(BaseModel):
+    endpoint: str
+    keys: PushSubscriptionKeys
+
+
+class PushSubscriptionInfo(BaseModel):
+    id: int
+    endpoint: str
+    createdAt: str
+
+
 # --- Tool Usage (system observability) ---
 
 

--- a/nanobot/api/push.py
+++ b/nanobot/api/push.py
@@ -1,0 +1,159 @@
+"""Web Push notification sender.
+
+Sends encrypted push notifications to subscribed browsers via the Web Push
+protocol.  Stale subscriptions (HTTP 404/410) are automatically removed.
+
+Usage:
+    from api.push import send_push_to_user
+
+    count = await send_push_to_user(
+        pool=db_pool,
+        user_id="ron",
+        title="Download complete",
+        body="Dune audiobook is ready in your library",
+    )
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from typing import Any
+
+from pywebpush import WebPushException, webpush
+
+from .config import settings
+
+logger = logging.getLogger(__name__)
+
+
+async def send_push_to_user(
+    pool: Any,
+    user_id: str,
+    title: str,
+    body: str,
+    url: str = "/",
+    category: str = "general",
+) -> int:
+    """Send a push notification to all of a user's subscribed devices.
+
+    Args:
+        pool: DatabasePool instance (has `pool` attribute for asyncpg pool).
+        user_id: Target user ID.
+        title: Notification title.
+        body: Notification body text.
+        url: URL to open when notification is clicked.
+        category: Notification category tag for grouping.
+
+    Returns:
+        Number of devices successfully notified.
+    """
+    if not settings.vapid_private_key:
+        logger.warning("Push notification skipped: VAPID keys not configured")
+        return 0
+
+    db = pool.pool
+    rows = await db.fetch(
+        "SELECT id, endpoint, key_p256dh, key_auth "
+        "FROM butler.push_subscriptions WHERE user_id = $1",
+        user_id,
+    )
+
+    if not rows:
+        return 0
+
+    payload = json.dumps({
+        "title": title,
+        "body": body,
+        "url": url,
+        "category": category,
+    })
+
+    sent = 0
+    stale_ids: list[int] = []
+
+    for row in rows:
+        subscription_info = {
+            "endpoint": row["endpoint"],
+            "keys": {
+                "p256dh": row["key_p256dh"],
+                "auth": row["key_auth"],
+            },
+        }
+        try:
+            await asyncio.to_thread(
+                webpush,
+                subscription_info=subscription_info,
+                data=payload,
+                vapid_private_key=settings.vapid_private_key,
+                vapid_claims={"sub": settings.vapid_subject},
+            )
+            sent += 1
+            # Update last_used_at
+            await db.execute(
+                "UPDATE butler.push_subscriptions SET last_used_at = NOW() WHERE id = $1",
+                row["id"],
+            )
+        except WebPushException as e:
+            status = getattr(e, "response", None)
+            status_code = getattr(status, "status_code", 0) if status else 0
+            if status_code in (404, 410):
+                # Subscription expired or unsubscribed — mark for removal
+                stale_ids.append(row["id"])
+                logger.info("Removing stale push subscription %d (HTTP %d)", row["id"], status_code)
+            else:
+                logger.warning("Push failed for subscription %d: %s", row["id"], e)
+        except Exception:
+            logger.exception("Unexpected error sending push to subscription %d", row["id"])
+
+    # Clean up stale subscriptions
+    if stale_ids:
+        try:
+            await db.execute(
+                "DELETE FROM butler.push_subscriptions WHERE id = ANY($1::int[])",
+                stale_ids,
+            )
+        except Exception:
+            logger.exception("Failed to cleanup %d stale push subscriptions", len(stale_ids))
+
+    return sent
+
+
+async def send_push_broadcast(
+    pool: Any,
+    title: str,
+    body: str,
+    url: str = "/",
+    category: str = "general",
+) -> int:
+    """Send a push notification to ALL subscribed users/devices.
+
+    Useful for system-wide announcements.
+
+    Returns:
+        Total number of devices successfully notified.
+    """
+    db = pool.pool
+    rows = await db.fetch(
+        "SELECT DISTINCT user_id FROM butler.push_subscriptions"
+    )
+
+    total = 0
+    for row in rows:
+        total += await send_push_to_user(pool, row["user_id"], title, body, url, category)
+    return total
+
+
+def create_push_channel(pool: Any):
+    """Create a NotificationDispatcher-compatible push channel.
+
+    Returns:
+        Async callable with signature (severity, title, message) -> bool.
+    """
+
+    async def channel(severity: str, title: str, message: str) -> bool:
+        count = await send_push_broadcast(pool, title, message, url="/", category="alert")
+        return count > 0
+
+    return channel

--- a/nanobot/api/routes/push.py
+++ b/nanobot/api/routes/push.py
@@ -1,0 +1,100 @@
+"""Push notification subscription management routes."""
+
+from fastapi import APIRouter, Depends, Query
+
+from tools import DatabasePool
+
+from ..config import settings
+from ..deps import get_current_user, get_db_pool
+from ..models import PushSubscribeRequest, PushSubscriptionInfo
+from ..push import send_push_to_user
+
+router = APIRouter()
+
+
+@router.get("/vapid-key")
+async def get_vapid_key():
+    """Return the public VAPID key for push subscription.
+
+    No auth required — the browser needs this to call pushManager.subscribe().
+    """
+    return {"vapidPublicKey": settings.vapid_public_key}
+
+
+@router.post("/subscribe", status_code=201)
+async def subscribe(
+    req: PushSubscribeRequest,
+    user_id: str = Depends(get_current_user),
+    pool: DatabasePool = Depends(get_db_pool),
+):
+    """Store a push subscription for the authenticated user."""
+    db = pool.pool
+    await db.execute(
+        """
+        INSERT INTO butler.push_subscriptions (user_id, endpoint, key_p256dh, key_auth)
+        VALUES ($1, $2, $3, $4)
+        ON CONFLICT (user_id, endpoint) DO UPDATE SET
+            key_p256dh = EXCLUDED.key_p256dh,
+            key_auth   = EXCLUDED.key_auth,
+            last_used_at = NOW()
+        """,
+        user_id,
+        req.endpoint,
+        req.keys.p256dh,
+        req.keys.auth,
+    )
+    return {"status": "subscribed"}
+
+
+@router.delete("/subscribe")
+async def unsubscribe(
+    endpoint: str = Query(..., description="The push subscription endpoint URL to remove"),
+    user_id: str = Depends(get_current_user),
+    pool: DatabasePool = Depends(get_db_pool),
+):
+    """Remove a push subscription for the authenticated user."""
+    db = pool.pool
+    await db.execute(
+        "DELETE FROM butler.push_subscriptions WHERE user_id = $1 AND endpoint = $2",
+        user_id,
+        endpoint,
+    )
+    return {"status": "unsubscribed"}
+
+
+@router.get("/subscriptions", response_model=list[PushSubscriptionInfo])
+async def list_subscriptions(
+    user_id: str = Depends(get_current_user),
+    pool: DatabasePool = Depends(get_db_pool),
+):
+    """List all push subscriptions for the authenticated user."""
+    db = pool.pool
+    rows = await db.fetch(
+        "SELECT id, endpoint, created_at FROM butler.push_subscriptions WHERE user_id = $1",
+        user_id,
+    )
+    return [
+        PushSubscriptionInfo(
+            id=r["id"],
+            endpoint=r["endpoint"],
+            createdAt=r["created_at"].isoformat(),
+        )
+        for r in rows
+    ]
+
+
+@router.post("/test")
+async def test_push(
+    user_id: str = Depends(get_current_user),
+    pool: DatabasePool = Depends(get_db_pool),
+):
+    """Send a test push notification to the authenticated user's devices."""
+    count = await send_push_to_user(
+        pool=pool,
+        user_id=user_id,
+        title="Butler Test",
+        body="Push notifications are working!",
+        url="/settings",
+        category="general",
+    )
+    return {"sent": count}

--- a/nanobot/api/server.py
+++ b/nanobot/api/server.py
@@ -9,7 +9,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from .config import settings
 from .deps import cleanup_resources, get_db_pool, init_resources
 from .ratelimit import RateLimitConfig, RateLimitMiddleware, SlidingWindowStore
-from .routes import admin, auth, chat, oauth, system, tasks, users, voice, webhooks
+from .routes import admin, auth, chat, oauth, push, system, tasks, users, voice, webhooks
 
 logger = logging.getLogger(__name__)
 
@@ -68,6 +68,7 @@ app.include_router(oauth.router, prefix="/api/oauth", tags=["oauth"])
 app.include_router(admin.router, prefix="/api/admin", tags=["admin"])
 app.include_router(system.router, prefix="/api", tags=["system"])
 app.include_router(webhooks.router, prefix="/api/webhooks", tags=["webhooks"])
+app.include_router(push.router, prefix="/api/push", tags=["push"])
 
 
 @app.get("/health")

--- a/nanobot/migrations/006_push_subscriptions.sql
+++ b/nanobot/migrations/006_push_subscriptions.sql
@@ -1,0 +1,16 @@
+-- Push notification subscriptions (Web Push API)
+-- Each row represents one browser/device subscription for a user.
+
+CREATE TABLE IF NOT EXISTS butler.push_subscriptions (
+    id          SERIAL PRIMARY KEY,
+    user_id     TEXT NOT NULL REFERENCES butler.users(id) ON DELETE CASCADE,
+    endpoint    TEXT NOT NULL,
+    key_p256dh  TEXT NOT NULL,
+    key_auth    TEXT NOT NULL,
+    created_at  TIMESTAMPTZ DEFAULT NOW(),
+    last_used_at TIMESTAMPTZ DEFAULT NOW(),
+    UNIQUE(user_id, endpoint)
+);
+
+CREATE INDEX IF NOT EXISTS idx_push_subs_user
+    ON butler.push_subscriptions(user_id);

--- a/nanobot/requirements-api.txt
+++ b/nanobot/requirements-api.txt
@@ -15,3 +15,6 @@ anthropic>=0.40.0
 # Auth
 PyJWT>=2.8.0
 livekit-api>=0.7.0
+
+# Push notifications (Web Push API)
+pywebpush>=2.0.0


### PR DESCRIPTION
Implements native OS notifications for the Butler PWA using the Web Push API. Users can now receive alerts even when the app is closed.

**Backend:** Push sender utility with asyncio.to_thread() to prevent event loop blocking, REST endpoints for subscription management, database migration for per-user/per-device subscriptions, and automatic cleanup of stale endpoints.

**Frontend:** Custom service worker handling push events, usePushNotifications hook for permission flow, Settings UI toggle (per-device), and switched vite-plugin-pwa to injectManifest strategy.

Closes #83