### PR TITLE
Pin Docker image tags to specific versions

### DIFF
--- a/docker/books-stack/docker-compose.yml
+++ b/docker/books-stack/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   calibre-web:
-    image: lscr.io/linuxserver/calibre-web:latest
+    image: lscr.io/linuxserver/calibre-web:0.6.25
     container_name: calibre-web
     environment:
       - PUID=501
@@ -17,7 +17,7 @@ services:
     restart: unless-stopped
 
   audiobookshelf:
-    image: ghcr.io/advplyr/audiobookshelf:latest
+    image: ghcr.io/advplyr/audiobookshelf:v2.32.1
     container_name: audiobookshelf
     environment:
       - TZ=Europe/London
@@ -33,7 +33,7 @@ services:
     restart: unless-stopped
 
   readarr:
-    image: lscr.io/linuxserver/readarr:develop
+    image: lscr.io/linuxserver/readarr:0.4.18-develop
     container_name: readarr
     environment:
       - PUID=501

--- a/docker/download-stack/docker-compose.yml
+++ b/docker/download-stack/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   qbittorrent:
-    image: lscr.io/linuxserver/qbittorrent:latest
+    image: lscr.io/linuxserver/qbittorrent:5.1.4
     container_name: qbittorrent
     environment:
       - PUID=501
@@ -19,7 +19,7 @@ services:
     restart: unless-stopped
 
   prowlarr:
-    image: lscr.io/linuxserver/prowlarr:latest
+    image: lscr.io/linuxserver/prowlarr:2.3.0
     container_name: prowlarr
     environment:
       - PUID=501

--- a/docker/media-stack/docker-compose.yml
+++ b/docker/media-stack/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   jellyfin:
-    image: jellyfin/jellyfin:latest
+    image: jellyfin/jellyfin:10.11.6
     container_name: jellyfin
     environment:
       - PUID=501
@@ -17,7 +17,7 @@ services:
     restart: unless-stopped
 
   radarr:
-    image: lscr.io/linuxserver/radarr:latest
+    image: lscr.io/linuxserver/radarr:6.0.4
     container_name: radarr
     environment:
       - PUID=501
@@ -34,7 +34,7 @@ services:
     restart: unless-stopped
 
   sonarr:
-    image: lscr.io/linuxserver/sonarr:latest
+    image: lscr.io/linuxserver/sonarr:4.0.16
     container_name: sonarr
     environment:
       - PUID=501
@@ -51,7 +51,7 @@ services:
     restart: unless-stopped
 
   bazarr:
-    image: lscr.io/linuxserver/bazarr:latest
+    image: lscr.io/linuxserver/bazarr:1.5.5
     container_name: bazarr
     environment:
       - PUID=501

--- a/docker/photos-files-stack/docker-compose.yml
+++ b/docker/photos-files-stack/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   immich-server:
-    image: ghcr.io/immich-app/immich-server:release
+    image: ghcr.io/immich-app/immich-server:v2.5.3
     container_name: immich-server
     volumes:
       - ${DRIVE_PATH:-/Volumes/HomeServer}/Photos/Immich:/usr/src/app/upload
@@ -21,7 +21,7 @@ services:
     restart: unless-stopped
 
   immich-machine-learning:
-    image: ghcr.io/immich-app/immich-machine-learning:release
+    image: ghcr.io/immich-app/immich-machine-learning:v2.5.3
     container_name: immich-machine-learning
     volumes:
       - immich-ml-cache:/cache
@@ -32,7 +32,7 @@ services:
     restart: unless-stopped
 
   immich-redis:
-    image: redis:alpine
+    image: redis:7.4.7-alpine
     container_name: immich-redis
     networks:
       - homeserver
@@ -54,7 +54,7 @@ services:
     restart: unless-stopped
 
   nextcloud:
-    image: nextcloud:latest
+    image: nextcloud:32.0.5
     container_name: nextcloud
     environment:
       - PUID=501

--- a/docker/smart-home-stack/docker-compose.yml
+++ b/docker/smart-home-stack/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   homeassistant:
-    image: homeassistant/home-assistant:stable
+    image: homeassistant/home-assistant:2026.2
     container_name: homeassistant
     environment:
       - TZ=Europe/London
@@ -14,7 +14,7 @@ services:
     restart: unless-stopped
 
   cloudflared:
-    image: cloudflare/cloudflared:latest
+    image: cloudflare/cloudflared:2026.1.2
     container_name: cloudflared
     command: tunnel --no-autoupdate run
     environment:

--- a/docker/voice-stack/docker-compose.yml
+++ b/docker/voice-stack/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   livekit:
-    image: livekit/livekit-server:latest
+    image: livekit/livekit-server:v1.9.11
     container_name: livekit
     command: --config /etc/livekit.yaml
     volumes:
@@ -14,7 +14,7 @@ services:
     restart: unless-stopped
 
   whisper:
-    image: onerahmet/openai-whisper-asr-webservice:latest
+    image: onerahmet/openai-whisper-asr-webservice:v1.9.1
     container_name: whisper
     environment:
       - ASR_MODEL=small
@@ -26,7 +26,7 @@ services:
     restart: unless-stopped
 
   kokoro-tts:
-    image: ghcr.io/remsky/kokoro-fastapi:latest
+    image: ghcr.io/remsky/kokoro-fastapi-cpu:v0.2.4
     container_name: kokoro-tts
     environment:
       - PYTHONUNBUFFERED=1


### PR DESCRIPTION
Closes #106

## Summary
- Replaced all `:latest`, `:stable`, `:release`, and `:develop` rolling tags with pinned version numbers across all 6 Docker Compose files (18 images total)
- Fixed `kokoro-fastapi` image name to use the correct `-cpu` variant (`ghcr.io/remsky/kokoro-fastapi-cpu:v0.2.4`) since the Mac Mini M4 has no NVIDIA GPU
- Immich postgres was already pinned — no change needed there

## Pinned versions

| Service | Image | Version |
|---------|-------|---------|
| Jellyfin | `jellyfin/jellyfin` | `10.11.6` |
| Radarr | `lscr.io/linuxserver/radarr` | `6.0.4` |
| Sonarr | `lscr.io/linuxserver/sonarr` | `4.0.16` |
| Bazarr | `lscr.io/linuxserver/bazarr` | `1.5.5` |
| qBittorrent | `lscr.io/linuxserver/qbittorrent` | `5.1.4` |
| Prowlarr | `lscr.io/linuxserver/prowlarr` | `2.3.0` |
| Calibre-Web | `lscr.io/linuxserver/calibre-web` | `0.6.25` |
| Audiobookshelf | `ghcr.io/advplyr/audiobookshelf` | `v2.32.1` |
| Readarr | `lscr.io/linuxserver/readarr` | `0.4.18-develop` |
| Immich Server | `ghcr.io/immich-app/immich-server` | `v2.5.3` |
| Immich ML | `ghcr.io/immich-app/immich-machine-learning` | `v2.5.3` |
| Redis | `redis` | `7.4.7-alpine` |
| Nextcloud | `nextcloud` | `32.0.5` |
| Home Assistant | `homeassistant/home-assistant` | `2026.2` |
| Cloudflared | `cloudflare/cloudflared` | `2026.1.2` |
| LiveKit | `livekit/livekit-server` | `v1.9.11` |
| Whisper ASR | `onerahmet/openai-whisper-asr-webservice` | `v1.9.1` |
| Kokoro TTS | `ghcr.io/remsky/kokoro-fastapi-cpu` | `v0.2.4` |

## Test plan
- [ ] Verify `docker compose config` parses cleanly for each stack
- [ ] Confirm `docker compose pull` resolves all pinned tags