### PR TITLE
Add phone number and notification preferences to user model

### DIFF
--- a/app/src/types/user.ts
+++ b/app/src/types/user.ts
@@ -13,6 +13,7 @@ export interface User {
   id: string
   name: string
   email?: string
+  phone?: string
   butlerName: string
   role: UserRole
   permissions: ToolPermission[]
@@ -26,9 +27,25 @@ export interface SoulConfig {
   customInstructions?: string
 }
 
+export type NotificationCategory =
+  | 'download'
+  | 'reminder'
+  | 'weather'
+  | 'smart_home'
+  | 'calendar'
+  | 'general'
+
+export interface NotificationPrefs {
+  enabled: boolean
+  categories: NotificationCategory[]
+  quietHoursStart?: string
+  quietHoursEnd?: string
+}
+
 export interface UserProfile extends User {
   soul: SoulConfig
   facts: UserFact[]
+  notificationPrefs: NotificationPrefs
 }
 
 export interface UserFact {

--- a/nanobot/api/models.py
+++ b/nanobot/api/models.py
@@ -96,6 +96,18 @@ class SoulConfig(BaseModel):
     customInstructions: str | None = None
 
 
+class NotificationPrefs(BaseModel):
+    enabled: bool = True
+    categories: list[str] = Field(
+        default_factory=lambda: [
+            "download", "reminder", "weather",
+            "smart_home", "calendar", "general",
+        ]
+    )
+    quietHoursStart: str | None = None  # "HH:MM" format
+    quietHoursEnd: str | None = None    # "HH:MM" format
+
+
 class UserFact(BaseModel):
     id: str
     content: str
@@ -107,17 +119,24 @@ class UserProfile(BaseModel):
     id: str
     name: str
     email: str | None = None
+    phone: str | None = None
     butlerName: str = "Butler"
     role: str = "user"
     permissions: list[str] = Field(default_factory=lambda: ["media", "home"])
     createdAt: str
     soul: SoulConfig = Field(default_factory=SoulConfig)
     facts: list[UserFact] = Field(default_factory=list)
+    notificationPrefs: NotificationPrefs = Field(default_factory=NotificationPrefs)
 
 
 class UpdateProfileRequest(BaseModel):
     name: str | None = None
     email: str | None = None
+
+
+class UpdateNotificationsRequest(BaseModel):
+    phone: str | None = Field(None, pattern=r'^$|^\+[1-9]\d{1,14}$')
+    notificationPrefs: NotificationPrefs | None = None
 
 
 class UpdateButlerNameRequest(BaseModel):

--- a/nanobot/api/routes/webhooks.py
+++ b/nanobot/api/routes/webhooks.py
@@ -110,7 +110,7 @@ async def _notify_users(
 ) -> bool:
     """Send a smart_home notification to all eligible users.
 
-    Eligible = whatsapp_phone configured AND smart_home category enabled.
+    Eligible = phone configured AND smart_home category enabled.
     The WhatsApp tool's own execute() handles preference checks, rate
     limiting, and quiet hours for each user individually.
 
@@ -120,8 +120,8 @@ async def _notify_users(
     rows = await db.fetch(
         """
         SELECT id FROM butler.users
-        WHERE soul -> 'whatsapp_phone' IS NOT NULL
-          AND soul ->> 'whatsapp_phone' != ''
+        WHERE phone IS NOT NULL
+          AND phone != ''
         """,
     )
 

--- a/nanobot/migrations/001_butler_schema.sql
+++ b/nanobot/migrations/001_butler_schema.sql
@@ -12,6 +12,9 @@ CREATE TABLE IF NOT EXISTS butler.users (
     id TEXT PRIMARY KEY,                    -- Unique identifier (phone number, telegram id, etc.)
     name TEXT NOT NULL,                     -- Display name
     soul JSONB DEFAULT '{}',                -- Personality/preference config
+    phone TEXT,                             -- E.164 phone number for WhatsApp notifications
+    notification_prefs JSONB NOT NULL       -- WhatsApp notification settings
+        DEFAULT '{"enabled": true, "categories": ["download", "reminder", "weather", "smart_home", "calendar", "general"]}',
     created_at TIMESTAMPTZ DEFAULT NOW(),
     updated_at TIMESTAMPTZ DEFAULT NOW()
 );


### PR DESCRIPTION
## Summary
Migrate WhatsApp phone and notification settings from the `soul` JSONB column into dedicated columns on `butler.users` for better separation of concerns. Add a Settings UI section to configure phone number, notification categories, and test WhatsApp delivery.

## Changes
- **Schema:** Add `phone` and `notification_prefs` columns to `butler.users` in base migration (no data migration needed—DB not yet deployed)
- **API:** New endpoints `PUT /user/notifications` and `POST /user/notifications/test` with transactional safety
- **Frontend:** WhatsApp Notifications settings panel with E.164 validation, category toggles, and test button
- **Tests:** Updated WhatsApp tool tests to reflect new schema structure
- **Bug fixes:** Transaction wrapper prevents partial saves; fixed test message success detection to recognize both "sent" and "queued" states

Closes #131