### PR TITLE
Remove unused local Whisper container from voice stack

### DIFF
--- a/HOMESERVER_PLAN.md
+++ b/HOMESERVER_PLAN.md
@@ -873,7 +873,7 @@ Nanobot is already minimal (~4k lines), but we further harden it:
 | | | | |
 | **Total Used** | **~147GB** | | |
 | **Reserved (30%)** | **~150GB** | | macOS health + future growth |
-| **Available** | **~200GB** | | Buffer for unexpected needs |
+| **Available** | **~203GB** | | Buffer for unexpected needs |
 
 #### 🔴 Critical: What MUST Stay on SSD
 
@@ -1283,7 +1283,6 @@ This does NOT protect against: Mac Mini theft/fire (use cloud for that).
 - [ ] Test Alexa → Home Assistant commands
 
 ### Phase 7: AI Butler (Day 6-7)
-- [ ] Deploy Whisper Turbo
 - [ ] Deploy Kokoro TTS
 - [ ] Build Butler Agent with Claude API
 - [ ] Define function schemas for all services

--- a/docker/voice-stack/docker-compose.yml
+++ b/docker/voice-stack/docker-compose.yml
@@ -19,24 +19,6 @@ services:
       retries: 3
       start_period: 15s
 
-  whisper:
-    image: onerahmet/openai-whisper-asr-webservice:v1.9.1
-    container_name: whisper
-    environment:
-      - ASR_MODEL=small
-      - ASR_ENGINE=openai_whisper
-    ports:
-      - "9000:9000"
-    networks:
-      - homeserver
-    restart: unless-stopped
-    healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:9000/health"]
-      interval: 30s
-      timeout: 10s
-      retries: 3
-      start_period: 120s
-
   kokoro-tts:
     image: ghcr.io/remsky/kokoro-fastapi-cpu:v0.2.4
     container_name: kokoro-tts

--- a/nanobot/tools/server_health.py
+++ b/nanobot/tools/server_health.py
@@ -110,10 +110,6 @@ DEFAULT_SERVICES: dict[str, dict[str, Any]] = {
         "url": "http://livekit:7880",
         "stack": "voice",
     },
-    "whisper": {
-        "url": "http://whisper:9000/health",
-        "stack": "voice",
-    },
     "kokoro-tts": {
         "url": "http://kokoro-tts:8880/health",
         "stack": "voice",


### PR DESCRIPTION
## Summary
- Removed the `whisper` service from `docker/voice-stack/docker-compose.yml` — saves ~1.5GB RAM and 3GB SSD
- Removed `whisper:9000` health check from `nanobot/tools/server_health.py`
- Updated `docs/12-voice-stack.md` — services table, flow diagram, latency, test commands, troubleshooting, and config sections
- Removed `Whisper Turbo model | 3GB` from SSD storage budget in `HOMESERVER_PLAN.md` and adjusted running totals (~150GB → ~147GB)
- Removed "Deploy Whisper Turbo" from Phase 7 checklist

## Context
The LiveKit agent uses Groq cloud STT (`groq.STT(model="whisper-large-v3-turbo")`), making the local Whisper container dead weight.

Additional stale Whisper references across the codebase are tracked in #137.

Closes #133

## Test plan
- [ ] Verify `docker compose config` validates in `docker/voice-stack/`
- [ ] Verify no broken cross-references in docs
- [ ] Confirm SSD budget totals are arithmetically correct