### PR TITLE
Clean up remaining local Whisper references (Closes #137)

### DIFF
--- a/HOMESERVER_PLAN.md
+++ b/HOMESERVER_PLAN.md
@@ -39,7 +39,7 @@
 │  │  └──────────┘ └──────────┘ └──────────┘ └──────────┘ └──────────┘  │   │
 │  │  ┌──────────┐ ┌──────────┐ ┌───────────────────────────────────┐   │   │
 │  │  │ Calibre  │ │Audiobook │ │         AI BUTLER                 │   │   │
-│  │  │   Web    │ │  shelf   │ │  Whisper + Agent + Kokoro         │   │   │
+│  │  │   Web    │ │  shelf   │ │  Agent + Kokoro TTS               │   │   │
 │  │  └──────────┘ └──────────┘ └───────────────────────────────────┘   │   │
 │  └─────────────────────────────────────────────────────────────────────┘   │
 │                                    │                                        │
@@ -1203,7 +1203,6 @@ This does NOT protect against: Mac Mini theft/fire (use cloud for that).
 | 8081 | qBittorrent | LAN only |
 | 8100 | Butler Agent | LAN only |
 | 8880 | Kokoro TTS | LAN only |
-| 9000 | Whisper | LAN only |
 
 ### Service Communication
 
@@ -1381,7 +1380,7 @@ All software used in this project with links to official sources.
 |----------|----------|---------|---------|
 | [LiveKit](https://livekit.io/) | [livekit.io](https://livekit.io/) | Open-source WebRTC server for real-time audio/video | Apache 2.0 |
 | [LiveKit Agents](https://github.com/livekit/agents) | [GitHub](https://github.com/livekit/agents) | Python framework for building voice AI agents | Apache 2.0 |
-| [OpenAI Whisper](https://github.com/openai/whisper) | [GitHub](https://github.com/openai/whisper) | Local speech-to-text model | MIT |
+| [Groq Whisper](https://console.groq.com/) | [groq.com](https://console.groq.com/) | Cloud speech-to-text (Whisper large-v3-turbo, free tier) | Commercial |
 | [Kokoro TTS](https://github.com/remsky/Kokoro-FastAPI) | [GitHub](https://github.com/remsky/Kokoro-FastAPI) | High-quality local text-to-speech | Apache 2.0 |
 | [Claude API](https://www.anthropic.com/api) | [anthropic.com](https://www.anthropic.com/api) | LLM for understanding, reasoning, function calling | Commercial |
 | [Nanobot](https://github.com/HKUDS/nanobot) | [GitHub](https://github.com/HKUDS/nanobot) | Ultra-lightweight AI agent framework (~4k lines) | MIT |

--- a/docs/13-nanobot.md
+++ b/docs/13-nanobot.md
@@ -298,7 +298,7 @@ Nanobot connects to multiple Docker networks:
 |---------|---------|---------|
 | `photos-files-stack_default` | immich-postgres | Database storage |
 | `smart-home-stack_default` | homeassistant | Smart home control |
-| `voice-stack_default` | livekit, whisper, kokoro | Voice features |
+| `voice-stack_default` | livekit, kokoro | Voice features |
 
 ## Resource Usage
 

--- a/nanobot/README.md
+++ b/nanobot/README.md
@@ -30,7 +30,7 @@ Nanobot connects to multiple services:
 |---------|---------|---------|
 | PostgreSQL | photos-files-stack | Memory storage (butler schema) |
 | LiveKit | voice-stack | Real-time voice |
-| Whisper | voice-stack | Speech-to-text |
+| Groq Whisper | Cloud API (free tier) | Speech-to-text |
 | Kokoro | voice-stack | Text-to-speech |
 | Home Assistant | smart-home-stack | Smart home control |
 

--- a/nanobot/api/routes/voice.py
+++ b/nanobot/api/routes/voice.py
@@ -41,7 +41,7 @@ async def process_voice(
     """Process a voice transcript and return an AI response.
 
     This is the core voice pipeline endpoint that LiveKit Agents calls
-    after Whisper transcribes the user's speech. The flow:
+    after Groq Whisper (cloud STT) transcribes the user's speech. The flow:
     1. Determine user_id (from JWT or request body for internal calls)
     2. Load user context (soul config, facts, conversation history)
     3. Call Claude with available tools

--- a/scripts/12-voice-stack.sh
+++ b/scripts/12-voice-stack.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Step 12: Deploy Voice Stack (LiveKit + Whisper + Kokoro TTS)
+# Step 12: Deploy Voice Stack (LiveKit + Kokoro TTS)
 set -e
 
 GREEN='\033[0;32m'
@@ -42,13 +42,6 @@ else
     echo -e "  ${YELLOW}⚠${NC} LiveKit may still be starting..."
 fi
 
-# Whisper
-if curl -s http://localhost:9000/health &>/dev/null 2>&1 || curl -s http://localhost:9000 &>/dev/null; then
-    echo -e "  ${GREEN}✓${NC} Whisper (STT) running at http://localhost:9000"
-else
-    echo -e "  ${YELLOW}⚠${NC} Whisper may still be loading model..."
-fi
-
 # Kokoro
 if curl -s http://localhost:8880/health &>/dev/null 2>&1 || curl -s http://localhost:8880 &>/dev/null; then
     echo -e "  ${GREEN}✓${NC} Kokoro (TTS) running at http://localhost:8880"
@@ -65,11 +58,6 @@ echo "  LiveKit Server:"
 echo "    - WebSocket: ws://localhost:7880"
 echo "    - Keys configured in docker/voice-stack/.env"
 echo "    - Config: docker/voice-stack/livekit.yaml"
-echo ""
-echo "  Whisper (Speech-to-Text):"
-echo "    - URL: http://localhost:9000"
-echo "    - Model: small (good balance of speed/accuracy)"
-echo "    - Test: curl -X POST http://localhost:9000/asr -F 'audio_file=@test.wav'"
 echo ""
 echo "  Kokoro (Text-to-Speech):"
 echo "    - URL: http://localhost:8880"

--- a/scripts/13-nanobot.sh
+++ b/scripts/13-nanobot.sh
@@ -219,7 +219,7 @@ if is_placeholder "$current_val"; then
     echo ""
     echo -e "${YELLOW}Groq API Key (for Voice)${NC}"
     echo "Free tier — sign up at: https://console.groq.com/keys"
-    echo "Provides fast speech-to-text via Whisper. Required for voice features."
+    echo "Provides fast cloud speech-to-text via Groq Whisper. Required for voice features."
     echo ""
     read -p "Enter your Groq API key (gsk_...) or press Enter to skip: " groq_key
 

--- a/setup.sh
+++ b/setup.sh
@@ -226,7 +226,6 @@ echo ""
 if [[ "$SKIP_VOICE" == "false" ]]; then
 echo "  Voice:"
 echo "    - LiveKit:         ws://localhost:7880"
-echo "    - Whisper:         http://localhost:9000"
 echo "    - Kokoro TTS:      http://localhost:8880"
 echo ""
 fi


### PR DESCRIPTION
## Summary

- Removes all stale references to a local Whisper container (removed in #138)
- Updates 7 files: architecture diagrams, port maps, setup scripts, docs, and code
- Clarifies that STT is now Groq cloud API, not a local container

## Changes by file

**Scripts:**
- `scripts/12-voice-stack.sh` — Remove Whisper health check and endpoint output
- `setup.sh` — Remove Whisper URL from completion summary
- `scripts/13-nanobot.sh` — Clarify "Groq Whisper" in Groq API key prompt

**Docs:**
- `HOMESERVER_PLAN.md` — Remove Whisper from architecture diagram, port map, and update software reference table
- `docs/13-nanobot.md` — Remove whisper from voice-stack network listing
- `nanobot/README.md` — Update architecture table: Whisper is now Groq cloud API

**Code:**
- `nanobot/api/routes/voice.py` — Clarify docstring references Groq Whisper (cloud STT)

## Test plan

- [ ] Verify no remaining references to local Whisper container (port 9000, health checks)
- [ ] Verify all "Whisper" mentions now say "Groq Whisper" or are in cloud API context
- [ ] Run `grep -ri 'localhost:9000' .` to confirm no port 9000 references remain

Closes #137