### PR TITLE
Wire up proactive alerts and auto-learning

### DIFF
--- a/butler/api/alert_dispatch.py
+++ b/butler/api/alert_dispatch.py
@@ -1,0 +1,56 @@
+"""Background alert dispatch loop.
+
+Polls for unsent alerts every 60 seconds and dispatches them through
+registered notification channels (Web Push, WhatsApp).
+
+Started/stopped via the FastAPI lifespan in deps.py.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+from tools.alerting import NotificationDispatcher
+
+logger = logging.getLogger(__name__)
+
+_INTERVAL_SECONDS = 60
+_dispatch_task: asyncio.Task | None = None
+
+
+async def _dispatch_loop(dispatcher: NotificationDispatcher) -> None:
+    """Infinite loop that dispatches pending alerts."""
+    while True:
+        try:
+            sent = await dispatcher.dispatch_pending()
+            if sent:
+                logger.info("Dispatched %d alert(s)", sent)
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.exception("Alert dispatch error")
+        await asyncio.sleep(_INTERVAL_SECONDS)
+
+
+def start_alert_dispatch(dispatcher: NotificationDispatcher) -> None:
+    """Spawn the background alert dispatch task."""
+    global _dispatch_task
+    _dispatch_task = asyncio.create_task(
+        _dispatch_loop(dispatcher),
+        name="butler-alert-dispatch",
+    )
+    logger.info("Alert dispatch started (interval=%ds)", _INTERVAL_SECONDS)
+
+
+async def stop_alert_dispatch() -> None:
+    """Cancel the background alert dispatch task if running."""
+    global _dispatch_task
+    if _dispatch_task is not None:
+        _dispatch_task.cancel()
+        try:
+            await _dispatch_task
+        except asyncio.CancelledError:
+            pass
+        _dispatch_task = None
+        logger.info("Alert dispatch stopped")

--- a/butler/api/auto_learn.py
+++ b/butler/api/auto_learn.py
@@ -1,0 +1,153 @@
+"""Auto-extract facts from conversations using a fast model.
+
+After each conversation, a background task calls Claude Haiku to identify
+personal facts about the user (preferences, schedules, relationships, etc.)
+and stores them with source='auto_extraction'.
+
+This runs as a fire-and-forget asyncio task so it never blocks the response.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+
+import anthropic
+
+from tools import DatabasePool
+from tools.embeddings import EmbeddingService
+from tools.memory import RememberFactTool
+
+from .config import settings
+
+logger = logging.getLogger(__name__)
+
+_EXTRACTION_MODEL = "claude-haiku-4-5-20251001"
+
+_EXTRACTION_PROMPT = """\
+Analyze this conversation and extract any personal facts about the user.
+
+Only extract facts about the USER (their preferences, habits, relationships, \
+schedule, health, work, etc.). Do NOT extract general knowledge or facts about \
+the assistant.
+
+Conversation:
+User: {user_message}
+Assistant: {assistant_response}
+
+Return a JSON array of extracted facts. Each fact should have:
+- "fact": A concise statement about the user (e.g., "Prefers Italian food")
+- "category": One of: preference, schedule, relationship, work, health, other
+- "confidence": A number between 0.5 and 0.9 (how confident this is a real fact)
+
+Return an empty array [] if there is nothing personal to learn.
+
+Respond with ONLY the JSON array, no other text."""
+
+# Minimum message length to bother analyzing — very short messages
+# like "hi" or "thanks" rarely contain learnable facts.
+_MIN_MESSAGE_LENGTH = 20
+
+
+async def extract_and_store_facts(
+    db_pool: DatabasePool,
+    user_id: str,
+    user_message: str,
+    assistant_response: str,
+    embedding_service: EmbeddingService | None = None,
+) -> None:
+    """Extract personal facts from a conversation and store them.
+
+    This function is designed to be called via ``asyncio.create_task()``
+    so it runs in the background without blocking the chat response.
+    """
+    if not settings.anthropic_api_key:
+        return
+
+    # Skip very short or trivial messages
+    if len(user_message) < _MIN_MESSAGE_LENGTH:
+        return
+
+    try:
+        facts = await _call_extraction_model(user_message, assistant_response)
+        if not facts:
+            return
+
+        remember = RememberFactTool(db_pool, embedding_service)
+        for fact_data in facts:
+            try:
+                await remember.execute(
+                    user_id=user_id,
+                    fact=fact_data["fact"],
+                    category=fact_data.get("category", "other"),
+                    confidence=fact_data.get("confidence", 0.7),
+                    source="auto_extraction",
+                )
+                logger.debug(
+                    "Auto-learned fact for user=%s: %s",
+                    user_id,
+                    fact_data["fact"],
+                )
+            except Exception:
+                logger.exception("Failed to store auto-extracted fact")
+
+        if facts:
+            logger.info(
+                "Auto-extracted %d fact(s) for user=%s", len(facts), user_id
+            )
+
+    except Exception:
+        logger.exception("Auto-learning failed for user=%s", user_id)
+
+
+async def _call_extraction_model(
+    user_message: str,
+    assistant_response: str,
+) -> list[dict]:
+    """Call Haiku to extract facts from a conversation turn."""
+    client = anthropic.AsyncAnthropic(api_key=settings.anthropic_api_key)
+
+    prompt = _EXTRACTION_PROMPT.format(
+        user_message=user_message,
+        assistant_response=assistant_response[:2000],  # Truncate long responses
+    )
+
+    response = await client.messages.create(
+        model=_EXTRACTION_MODEL,
+        max_tokens=512,
+        messages=[{"role": "user", "content": prompt}],
+    )
+
+    text = response.content[0].text.strip()
+
+    # Parse JSON response
+    try:
+        facts = json.loads(text)
+    except json.JSONDecodeError:
+        logger.warning("Auto-learn: failed to parse Haiku response: %s", text[:200])
+        return []
+
+    if not isinstance(facts, list):
+        return []
+
+    # Validate and sanitize each fact
+    valid_categories = {"preference", "schedule", "relationship", "work", "health", "other"}
+    validated = []
+    for item in facts:
+        if not isinstance(item, dict) or "fact" not in item:
+            continue
+        category = item.get("category", "other")
+        if category not in valid_categories:
+            category = "other"
+        confidence = item.get("confidence", 0.7)
+        if not isinstance(confidence, (int, float)):
+            confidence = 0.7
+        confidence = max(0.5, min(0.9, confidence))
+
+        validated.append({
+            "fact": str(item["fact"])[:500],  # Cap fact length
+            "category": category,
+            "confidence": confidence,
+        })
+
+    return validated

--- a/butler/api/routes/chat.py
+++ b/butler/api/routes/chat.py
@@ -7,6 +7,7 @@ Same pipeline as voice but with 'pwa' channel tag.
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 import uuid
@@ -17,6 +18,7 @@ from starlette.responses import StreamingResponse
 
 from tools import DatabasePool, Tool
 
+from ..auto_learn import extract_and_store_facts
 from ..context import load_user_context
 from ..deps import get_current_user, get_db_pool, get_embedding_service, get_tools, get_user_tools
 from ..llm import chat_with_tools, stream_chat_with_events
@@ -77,6 +79,13 @@ async def text_chat(
         user_id,
         response_text,
         json.dumps({"message_id": message_id}),
+    )
+
+    # Auto-learn: extract facts in the background (fire-and-forget)
+    asyncio.create_task(
+        extract_and_store_facts(
+            pool, user_id, req.message, response_text, get_embedding_service()
+        )
     )
 
     return ChatResponse(response=response_text, message_id=message_id)
@@ -197,6 +206,13 @@ async def stream_text_chat(
                         user_id,
                         full_text,
                         json.dumps({"message_id": message_id}),
+                    )
+                    # Auto-learn: extract facts in the background
+                    asyncio.create_task(
+                        extract_and_store_facts(
+                            pool, user_id, req.message, full_text,
+                            get_embedding_service(),
+                        )
                     )
                 except Exception:
                     logger.exception(

--- a/butler/tools/memory.py
+++ b/butler/tools/memory.py
@@ -180,6 +180,7 @@ class RememberFactTool(DatabaseTool):
         fact = kwargs["fact"]
         category = kwargs.get("category", "other")
         confidence = kwargs.get("confidence", 1.0)
+        source = kwargs.get("source", "conversation")
 
         pool = await self._get_pool()
 
@@ -207,18 +208,18 @@ class RememberFactTool(DatabaseTool):
                 """
                 INSERT INTO butler.user_facts
                     (user_id, fact, category, confidence, source, embedding)
-                VALUES ($1, $2, $3, $4, 'conversation', $5::vector)
+                VALUES ($1, $2, $3, $4, $5, $6::vector)
                 """,
-                user_id, fact, category, confidence, vector_str
+                user_id, fact, category, confidence, source, vector_str
             )
         else:
             await pool.execute(
                 """
                 INSERT INTO butler.user_facts
                     (user_id, fact, category, confidence, source)
-                VALUES ($1, $2, $3, $4, 'conversation')
+                VALUES ($1, $2, $3, $4, $5)
                 """,
-                user_id, fact, category, confidence
+                user_id, fact, category, confidence, source
             )
 
         return f"Remembered: {fact}"


### PR DESCRIPTION
## Summary
- **5a: Alert dispatch** — Instantiate `NotificationDispatcher` at startup, register Web Push + WhatsApp channels, run a 60s background dispatch loop that sends unsent alerts to admin users
- **5b: Default schedules** — Seed health check (every 6h) and storage check (daily 9am) as system-level scheduled tasks on first startup, with idempotent `WHERE NOT EXISTS` guards
- **5c: Auto-learning** — After each chat conversation, fire a background Haiku call to extract personal facts (preferences, relationships, schedule, etc.) and store them with `source='auto_extraction'`

## Files changed
| File | Change |
|------|--------|
| `butler/api/alert_dispatch.py` | **New** — Background loop calling `dispatch_pending()` every 60s |
| `butler/api/auto_learn.py` | **New** — Haiku-based fact extraction from conversations |
| `butler/api/deps.py` | Wire dispatcher + channels at startup, seed schedules, cleanup on shutdown |
| `butler/api/push.py` | Add `create_whatsapp_channel()` adapter for NotificationDispatcher |
| `butler/api/scheduler.py` | Add `seed_default_schedules()` with system user + two default checks |
| `butler/api/routes/chat.py` | Add fire-and-forget auto-learn hook to both batch and streaming chat |
| `butler/tools/memory.py` | Accept `source` kwarg in `RememberFactTool` (was hardcoded to `'conversation'`) |

## Test plan
- [ ] Start server, verify `Alert dispatch started` and `Default schedules seeded` in logs
- [ ] Check `butler.scheduled_tasks` table for two system-level entries
- [ ] Manually trigger a health alert, verify it dispatches via push/WhatsApp within 60s
- [ ] Send a chat message containing a personal preference, verify `butler.user_facts` gets a new row with `source='auto_extraction'`
- [ ] Verify explicit `remember_fact` tool calls still save with `source='conversation'`

Closes #146