### PR TITLE
Fix setup.sh stdin handling and Google OAuth docs

### DIFF
--- a/docs/google-oauth-setup.md
+++ b/docs/google-oauth-setup.md
@@ -38,8 +38,8 @@ This guide walks you through creating Google OAuth credentials so Butler can acc
 
 ## 4. Create OAuth 2.0 Credentials
 
-1. Go to **APIs & Services > Credentials**
-2. Click **Create Credentials > OAuth client ID**
+1. Go to **Clients** (in the left sidebar under your project)
+2. Click **Create OAuth client ID**
 3. Choose **Web application** as the application type
 4. Name it `Butler Web`
 5. Under **Authorized redirect URIs**, add:


### PR DESCRIPTION
## Summary
Fixed two issues discovered during Mac Mini setup:

1. **setup.sh stdin problem** — When scripts are chained via `curl | bash`, stdin gets consumed by the pipe, preventing child scripts from prompting for sudo passwords. Now downloads scripts to temp files and runs with `< /dev/tty` to preserve TTY access.

2. **Google OAuth docs** — Updated navigation instructions to reflect Google Cloud Console's new UI (the Clients section has moved).

## Testing
Tested on Mac Mini with fresh setup. Homebrew installer can now prompt for password when running `setup.sh`.