### PR TITLE
Fix SSH setup failure on macOS Ventura+

### DIFF
--- a/docs/04-ssh.md
+++ b/docs/04-ssh.md
@@ -117,8 +117,13 @@ ssh -L 8096:localhost:8096 -L 8123:localhost:8123 macmini
 
 ## Troubleshooting
 
+**"Turning Remote Login on or off requires Full Disk Access privileges"**
+- The `systemsetup` command needs Full Disk Access on macOS Ventura+
+- **Easiest fix:** Enable via System Settings → General → Sharing → Remote Login
+- **Alternative:** Grant Terminal Full Disk Access in System Settings → Privacy & Security → Full Disk Access
+
 **"Connection refused"**
-- SSH not enabled: `sudo systemsetup -setremotelogin on`
+- SSH not enabled: enable via System Settings → General → Sharing → Remote Login
 - Firewall blocking port 22
 
 **"Host key verification failed"**

--- a/scripts/04-ssh.sh
+++ b/scripts/04-ssh.sh
@@ -4,6 +4,7 @@ set -e
 
 GREEN='\033[0;32m'
 BLUE='\033[0;34m'
+YELLOW='\033[1;33m'
 NC='\033[0m'
 
 CURRENT_USER=$(whoami)
@@ -13,8 +14,19 @@ echo -e "${BLUE}==>${NC} Enabling SSH..."
 if sudo systemsetup -getremotelogin 2>/dev/null | grep -q "On"; then
     echo -e "${GREEN}✓${NC} SSH already enabled"
 else
-    sudo systemsetup -setremotelogin on
-    echo -e "${GREEN}✓${NC} SSH enabled"
+    if sudo systemsetup -setremotelogin on 2>/dev/null; then
+        echo -e "${GREEN}✓${NC} SSH enabled"
+    else
+        echo -e "${YELLOW}⚠${NC} Could not enable SSH via systemsetup (requires Full Disk Access)."
+        echo ""
+        echo "  Please enable SSH manually:"
+        echo "    System Settings → General → Sharing → Remote Login → ON"
+        echo ""
+        echo "  Or grant Full Disk Access to Terminal, then re-run this script:"
+        echo "    System Settings → Privacy & Security → Full Disk Access → add Terminal.app"
+        echo ""
+        read -rp "  Press Enter once you've enabled Remote Login to continue..." < /dev/tty
+    fi
 fi
 
 # Prepare SSH directory


### PR DESCRIPTION
## Summary
- Handle `systemsetup -setremotelogin` failure gracefully when Full Disk Access isn't granted
- Show clear manual instructions and pause for user instead of aborting setup
- Add Full Disk Access troubleshooting entry to docs/04-ssh.md

Closes #160

## Test plan
- [ ] Run `scripts/04-ssh.sh` on macOS Ventura+ without Full Disk Access granted to Terminal
- [ ] Verify setup pauses with instructions instead of crashing
- [ ] Verify setup continues after user presses Enter
- [ ] Run `setup.sh` end-to-end on Mac Mini