### PR TITLE
Add self-update tool and fix identified issues

### DIFF
--- a/butler/api/deps.py
+++ b/butler/api/deps.py
@@ -33,6 +33,7 @@ from tools import (
     StorageMonitorTool,
     Tool,
     WeatherTool,
+    SelfUpdateTool,
     WhatsAppTool,
 )
 
@@ -64,6 +65,7 @@ PERMISSION_TOOL_MAP: dict[str, list[str]] = {
     "email": ["gmail"],
     "automation": ["schedule_task"],
     "communication": ["whatsapp"],
+    "admin": ["self_update"],
 }
 
 ALL_PERMISSION_GROUPS: list[str] = sorted(PERMISSION_TOOL_MAP.keys())
@@ -189,6 +191,9 @@ async def init_resources() -> None:
 
     # Schedule task tool (always registered — uses DB only)
     _tools["schedule_task"] = ScheduleTaskTool(_db_pool)
+
+    # Self-update tool (always registered — admin permission required)
+    _tools["self_update"] = SelfUpdateTool()
 
     # ── Alert dispatch ──────────────────────────────────────────────
     # Wire NotificationDispatcher with Push + WhatsApp channels so that

--- a/butler/tools/__init__.py
+++ b/butler/tools/__init__.py
@@ -43,6 +43,7 @@ from .server_health import ServerHealthTool
 from .storage_monitor import StorageMonitorTool
 from .schedule_task import ScheduleTaskTool
 from .whatsapp import WhatsAppTool
+from .self_update import SelfUpdateTool
 
 __all__ = [
     # Base
@@ -91,4 +92,6 @@ __all__ = [
     "ScheduleTaskTool",
     # WhatsApp
     "WhatsAppTool",
+    # Self-update
+    "SelfUpdateTool",
 ]

--- a/butler/tools/self_update.py
+++ b/butler/tools/self_update.py
@@ -1,0 +1,101 @@
+"""Self-update tool for Butler.
+
+Allows Butler to check for and apply updates from the GitHub repo.
+Runs the update.sh script which pulls changes and rebuilds only
+the Docker stacks that have changed files.
+
+Usage:
+    tool = SelfUpdateTool()
+    result = await tool.execute(action="check")   # check for updates
+    result = await tool.execute(action="update")   # pull and rebuild
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import re
+from typing import Any
+
+from .base import Tool
+
+logger = logging.getLogger(__name__)
+
+REPO_DIR = os.environ.get("REPO_DIR", os.path.expanduser("~/home-server"))
+UPDATE_SCRIPT = os.path.join(REPO_DIR, "scripts", "update.sh")
+
+
+class SelfUpdateTool(Tool):
+    """Check for and apply home server updates from GitHub."""
+
+    @property
+    def name(self) -> str:
+        return "self_update"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Check for home server updates from GitHub and optionally apply them. "
+            "Use 'check' to see if updates are available, 'update' to pull and "
+            "rebuild changed stacks."
+        )
+
+    @property
+    def parameters(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "action": {
+                    "type": "string",
+                    "enum": ["check", "update"],
+                    "description": (
+                        "check: See if updates are available without applying. "
+                        "update: Pull changes and rebuild affected Docker stacks."
+                    ),
+                },
+            },
+            "required": ["action"],
+        }
+
+    async def execute(self, **kwargs: Any) -> str:
+        action = kwargs.get("action", "")
+
+        if action not in ("check", "update"):
+            return f"Error: Unknown action '{action}'. Use 'check' or 'update'."
+
+        if not os.path.isfile(UPDATE_SCRIPT):
+            return (
+                f"Error: Update script not found at {UPDATE_SCRIPT}. "
+                f"Make sure the repo is cloned at {REPO_DIR}."
+            )
+
+        args = ["bash", UPDATE_SCRIPT]
+        if action == "check":
+            args.append("--check")
+
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                *args,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.STDOUT,
+                env={**os.environ, "REPO_DIR": REPO_DIR},
+            )
+            stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=300)
+            output = stdout.decode().strip()
+
+            # Strip ANSI color codes for cleaner LLM output
+            output = re.sub(r"\033\[[0-9;]*m", "", output)
+
+            if proc.returncode != 0:
+                return f"Update failed (exit {proc.returncode}):\n{output}"
+
+            return output
+
+        except asyncio.TimeoutError:
+            proc.kill()
+            await proc.wait()
+            return "Error: Update timed out after 5 minutes."
+        except Exception as e:
+            logger.exception("Self-update failed")
+            return f"Error running update: {e}"

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -1,0 +1,144 @@
+#!/bin/bash
+# Home Server Update Script
+#
+# Pulls latest changes from GitHub and rebuilds only the Docker stacks
+# that have changed. Can be run manually or called by Butler.
+#
+# Usage:
+#   bash ~/home-server/scripts/update.sh          # check & update
+#   bash ~/home-server/scripts/update.sh --check   # check only, no rebuild
+#   bash ~/home-server/scripts/update.sh --force   # rebuild all stacks
+
+set -e
+
+GREEN='\033[0;32m'
+BLUE='\033[0;34m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+REPO_DIR="${REPO_DIR:-$HOME/home-server}"
+CHECK_ONLY=false
+FORCE=false
+
+for arg in "$@"; do
+    case $arg in
+        --check) CHECK_ONLY=true ;;
+        --force) FORCE=true ;;
+    esac
+done
+
+if [[ ! -d "$REPO_DIR/.git" ]]; then
+    echo "Error: Repo not found at $REPO_DIR"
+    echo "Run: git clone https://github.com/noble1911/home-server.git $REPO_DIR"
+    exit 1
+fi
+
+cd "$REPO_DIR"
+
+# Ensure we're on the main branch
+CURRENT_BRANCH=$(git branch --show-current)
+if [[ "$CURRENT_BRANCH" != "main" ]]; then
+    echo -e "${YELLOW}⚠${NC} Not on main branch (on ${CURRENT_BRANCH}), switching..."
+    git checkout main --quiet
+fi
+
+# Fetch latest without merging
+git fetch origin main --quiet
+
+LOCAL=$(git rev-parse HEAD)
+REMOTE=$(git rev-parse origin/main)
+
+if [[ "$LOCAL" == "$REMOTE" ]] && [[ "$FORCE" == "false" ]]; then
+    echo -e "${GREEN}✓${NC} Already up to date"
+    exit 0
+fi
+
+# Show what changed
+COMMITS=$(git log --oneline HEAD..origin/main 2>/dev/null || true)
+COMMIT_COUNT=$(echo "$COMMITS" | grep -c . || echo 0)
+
+echo -e "${BLUE}==>${NC} ${COMMIT_COUNT} new commit(s) available:"
+echo "$COMMITS" | head -10
+if [[ "$COMMIT_COUNT" -gt 10 ]]; then
+    echo "  ... and $((COMMIT_COUNT - 10)) more"
+fi
+
+# Determine which stacks need rebuilding
+CHANGED_FILES=$(git diff --name-only HEAD..origin/main 2>/dev/null)
+
+# Map changed files to their docker-compose stacks
+declare -A STACKS
+STACKS=(
+    ["docker/media-stack"]="docker/media-stack/docker-compose.yml"
+    ["docker/download-stack"]="docker/download-stack/docker-compose.yml"
+    ["docker/books-stack"]="docker/books-stack/docker-compose.yml"
+    ["docker/photos-files-stack"]="docker/photos-files-stack/docker-compose.yml"
+    ["docker/smart-home-stack"]="docker/smart-home-stack/docker-compose.yml"
+    ["docker/voice-stack"]="docker/voice-stack/docker-compose.yml"
+    ["docker/messaging-stack"]="docker/messaging-stack/docker-compose.yml"
+    ["butler"]="butler/docker-compose.yml"
+    ["app"]="app/docker-compose.yml"
+)
+
+REBUILD_STACKS=()
+
+if [[ "$FORCE" == "true" ]]; then
+    for stack_dir in "${!STACKS[@]}"; do
+        compose_file="${STACKS[$stack_dir]}"
+        if [[ -f "$compose_file" ]]; then
+            REBUILD_STACKS+=("$compose_file")
+        fi
+    done
+else
+    for stack_dir in "${!STACKS[@]}"; do
+        if echo "$CHANGED_FILES" | grep -q "^${stack_dir}/"; then
+            compose_file="${STACKS[$stack_dir]}"
+            if [[ -f "$compose_file" ]]; then
+                REBUILD_STACKS+=("$compose_file")
+            fi
+        fi
+    done
+fi
+
+# Also rebuild butler if scripts/lib changed (shared helpers)
+if echo "$CHANGED_FILES" | grep -q "^scripts/lib/"; then
+    echo -e "  ${YELLOW}⚠${NC} Shared helpers changed — review scripts manually"
+fi
+
+echo ""
+if [[ ${#REBUILD_STACKS[@]} -eq 0 ]]; then
+    echo -e "${GREEN}✓${NC} No Docker stacks need rebuilding (only non-Docker files changed)"
+else
+    echo -e "${BLUE}==>${NC} Stacks to rebuild:"
+    for f in "${REBUILD_STACKS[@]}"; do
+        echo "    - $f"
+    done
+fi
+
+if [[ "$CHECK_ONLY" == "true" ]]; then
+    echo ""
+    echo "Run without --check to apply updates."
+    exit 0
+fi
+
+# Pull changes
+echo ""
+echo -e "${BLUE}==>${NC} Pulling changes..."
+if ! git pull --ff-only origin main; then
+    echo -e "${YELLOW}⚠${NC} Fast-forward pull failed — local main may have diverged."
+    echo "  Run 'cd $REPO_DIR && git status' to investigate."
+    exit 1
+fi
+
+# Rebuild affected stacks
+if [[ ${#REBUILD_STACKS[@]} -gt 0 ]]; then
+    echo ""
+    for compose_file in "${REBUILD_STACKS[@]}"; do
+        echo -e "${BLUE}==>${NC} Rebuilding $(dirname "$compose_file")..."
+        docker compose -f "$compose_file" up -d --build --remove-orphans
+        echo -e "  ${GREEN}✓${NC} $(dirname "$compose_file") updated"
+    done
+fi
+
+echo ""
+echo -e "${GREEN}✓${NC} Update complete ($(git rev-parse --short HEAD))"

--- a/setup.sh
+++ b/setup.sh
@@ -208,6 +208,18 @@ else
     echo -e "\n${YELLOW}==>${NC} Skipping Butler API (--skip-butler flag)"
 fi
 
+# Clone repo locally for future updates
+REPO_DIR="$HOME/home-server"
+echo -e "\n${GREEN}Cloning repo for future updates${NC}"
+if [[ -d "$REPO_DIR/.git" ]]; then
+    echo -e "  ${GREEN}✓${NC} Repo already cloned at ${REPO_DIR}"
+    git -C "$REPO_DIR" pull --ff-only 2>&1 || echo -e "  ${YELLOW}⚠${NC} Could not pull latest — run 'git -C $REPO_DIR pull' manually"
+else
+    git clone https://github.com/noble1911/home-server.git "$REPO_DIR" 2>/dev/null && \
+        echo -e "  ${GREEN}✓${NC} Repo cloned to ${REPO_DIR}" || \
+        echo -e "  ${YELLOW}⚠${NC} Could not clone repo — clone it manually later: git clone https://github.com/noble1911/home-server.git ${REPO_DIR}"
+fi
+
 # Summary
 echo ""
 echo -e "${GREEN}"
@@ -276,4 +288,9 @@ fi
 echo ""
 fi
 echo -e "${YELLOW}Credentials saved to:${NC} ~/.homeserver-credentials"
+echo ""
+echo -e "${GREEN}Updating services:${NC}"
+echo "  cd ~/home-server && git pull"
+echo "  Then rebuild the stack you changed, e.g.:"
+echo "    docker compose -f docker/media-stack/docker-compose.yml up -d --build"
 echo ""


### PR DESCRIPTION
## Summary
Implements a self-update mechanism allowing Butler to check for and apply updates from GitHub, selectively rebuilding only affected Docker stacks. Includes security fixes for subprocess handling and proper error recovery.

## Changes
- **SelfUpdateTool**: New Butler tool with `check` and `update` actions
- **update.sh**: Smart update script that diffs files and rebuilds only changed stacks
- **deps.py**: Register tool with admin permission gating
- **Security**: Use `create_subprocess_exec` instead of shell, handle timeouts with cleanup
- **Robustness**: Branch validation, error messages instead of silent failures

## Test plan
- [ ] Test `butler check` shows available updates without applying
- [ ] Test `butler update` applies updates and rebuilds affected stacks
- [ ] Verify admin permission gate prevents non-admin users from triggering updates
- [ ] Test error handling: timeout recovery, branch switching, git pull failures