### PR TITLE
Fix setup bugs: missing Nextcloud DB, DRIVE_PATH not persisted

### DIFF
--- a/scripts/10-photos-files.sh
+++ b/scripts/10-photos-files.sh
@@ -56,10 +56,18 @@ echo -e "${BLUE}==>${NC} Setting up Butler schema for AI memory..."
 "$SCRIPT_DIR/init-butler-schema.sh"
 
 # ─────────────────────────────────────────────
-# Nextcloud: Auto-install via occ CLI
+# Nextcloud: Create database + auto-install via occ CLI
 # ─────────────────────────────────────────────
 echo ""
 echo -e "${BLUE}==>${NC} Configuring Nextcloud..."
+
+# Create Nextcloud database if it doesn't exist (PostgreSQL only auto-creates the 'immich' DB)
+if ! docker exec immich-postgres psql -U postgres -lqt | cut -d \| -f 1 | grep -qw nextcloud; then
+    docker exec immich-postgres psql -U postgres -c "CREATE DATABASE nextcloud;" &>/dev/null
+    echo -e "  ${GREEN}✓${NC} Created nextcloud database"
+else
+    echo -e "  ${GREEN}✓${NC} Nextcloud database exists"
+fi
 
 NC_STATUS=$(docker exec -u www-data nextcloud php occ status --output=json 2>/dev/null || echo '{}')
 

--- a/scripts/13-butler.sh
+++ b/scripts/13-butler.sh
@@ -12,6 +12,13 @@ NC='\033[0m'
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 BUTLER_DIR="${SCRIPT_DIR}/../butler"
 
+# Source shared helpers and load DRIVE_PATH + credentials
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/configure-helpers.sh"
+load_credentials || true
+DRIVE_PATH="${DRIVE_PATH:-/Volumes/HomeServer}"
+export DRIVE_PATH
+
 # ──────────────────────────────────────────────────
 # Helper functions (idempotent key=value operations)
 # ──────────────────────────────────────────────────

--- a/setup.sh
+++ b/setup.sh
@@ -190,6 +190,14 @@ else
     echo -e "  Using ${DRIVE_PATH} on internal SSD instead"
 fi
 
+# Persist DRIVE_PATH so individual scripts can be re-run without the export
+if ! grep -q "^DRIVE_PATH=" "$CREDENTIALS_FILE" 2>/dev/null; then
+    echo "" >> "$CREDENTIALS_FILE"
+    echo "# Data directory" >> "$CREDENTIALS_FILE"
+    printf 'DRIVE_PATH=%s\n' "$DRIVE_PATH" >> "$CREDENTIALS_FILE"
+    echo -e "  ${GREEN}✓${NC} DRIVE_PATH saved to credentials file"
+fi
+
 # Clone repo — scripts 07+ need sibling files (docker-compose, configs, lib/)
 REPO_DIR="$HOME/home-server"
 echo -e "\n${BLUE}==>${NC} Cloning repo for local scripts..."


### PR DESCRIPTION
## Summary
- **Create `nextcloud` database before install**: PostgreSQL's `POSTGRES_DB=immich` only auto-creates the `immich` DB. Nextcloud's `occ maintenance:install` fails with `FATAL: database "nextcloud" does not exist`. Now creates it explicitly in `10-photos-files.sh`.
- **Persist `DRIVE_PATH` to credentials file**: When using `--skip-drive`, `DRIVE_PATH=$HOME/HomeServer` was only held in memory during `setup.sh`. Re-running individual scripts later (e.g. `13-butler.sh`) would default to `/Volumes/HomeServer` which doesn't exist, causing Docker bind mount failures. Now saved to `~/.homeserver-credentials`.
- **Add `load_credentials` to `13-butler.sh`**: Was the only script missing this call, so it never picked up the persisted `DRIVE_PATH`. Now consistent with scripts 07-10.

## Test plan
- [ ] Run `setup.sh --skip-drive` on a fresh system — verify all steps complete including Nextcloud and Butler
- [ ] After setup, re-run `bash scripts/13-butler.sh` standalone — verify it picks up DRIVE_PATH without manual export
- [ ] Verify `~/.homeserver-credentials` contains `DRIVE_PATH=` line after setup
- [ ] Verify Nextcloud is accessible at http://localhost:8080 after `10-photos-files.sh`