### PR TITLE
Fix services tab: show real URLs, remove broken deep links

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,6 +282,22 @@ Now that services are running, go back to the Cloudflare dashboard and add route
 
 3. After adding routes, verify each service loads via its `https://subdomain.yourdomain.com` URL
 
+4. **Update Butler app service URLs** — so the Services tab links to your tunnel URLs instead of LAN addresses. Create `app/.env` with your subdomains:
+
+   ```env
+   VITE_JELLYFIN_URL=https://jellyfin.yourdomain.com
+   VITE_AUDIOBOOKSHELF_URL=https://books.yourdomain.com
+   VITE_SHELFARR_URL=https://shelfarr.yourdomain.com
+   VITE_IMMICH_URL=https://photos.yourdomain.com
+   VITE_NEXTCLOUD_URL=https://files.yourdomain.com
+   VITE_HOMEASSISTANT_URL=https://ha.yourdomain.com
+   VITE_SEERR_URL=https://requests.yourdomain.com
+   ```
+
+   Then rebuild the Butler app: `cd app && npm run build` (or rebuild the Docker image).
+
+> **Note:** On LAN, service URLs auto-detect from the browser hostname (e.g. `http://192.168.1.22:8096`), so no configuration is needed for local access.
+
 ### 4.2 Set Up Butler (AI Assistant)
 
 Butler uses **invite codes** for registration. The first person to log in becomes the admin.

--- a/app/.env.example
+++ b/app/.env.example
@@ -1,13 +1,18 @@
 VITE_API_URL=http://localhost:8000/api
 VITE_LIVEKIT_URL=ws://localhost:7880
 
-# Service URLs — set VITE_SERVICE_HOSTNAME for Cloudflare Tunnel/remote access,
-# or override individual services with VITE_<SERVICE>_URL.
-# VITE_SERVICE_HOSTNAME=home.yourdomain.com
-# VITE_JELLYFIN_URL=http://jellyfin.local:8096
-# VITE_AUDIOBOOKSHELF_URL=http://audiobooks.local:13378
-# VITE_SHELFARR_URL=http://shelfarr.local:5056
-# VITE_IMMICH_URL=http://photos.local:2283
-# VITE_NEXTCLOUD_URL=http://files.local
-# VITE_HOMEASSISTANT_URL=http://ha.local:8123
-# VITE_SEERR_URL=http://requests.local:5055
+# Service URLs for the Services tab.
+#
+# On LAN: URLs auto-detect from the browser hostname (e.g. http://192.168.1.22:8096).
+#          No configuration needed if you access Butler on the same network.
+#
+# With Cloudflare Tunnel: Set each service URL to its tunnel subdomain.
+#          These are baked in at build time (Vite), so rebuild after changing.
+#
+# VITE_JELLYFIN_URL=https://jellyfin.yourdomain.com
+# VITE_AUDIOBOOKSHELF_URL=https://books.yourdomain.com
+# VITE_SHELFARR_URL=https://shelfarr.yourdomain.com
+# VITE_IMMICH_URL=https://photos.yourdomain.com
+# VITE_NEXTCLOUD_URL=https://files.yourdomain.com
+# VITE_HOMEASSISTANT_URL=https://ha.yourdomain.com
+# VITE_SEERR_URL=https://requests.yourdomain.com

--- a/app/src/components/services/ServiceCard.tsx
+++ b/app/src/components/services/ServiceCard.tsx
@@ -1,5 +1,4 @@
 import type { Service } from '../../types/services'
-import { isMobile } from '../../utils/device'
 
 interface ServiceCardProps {
   service: Service
@@ -9,8 +8,7 @@ interface ServiceCardProps {
 export default function ServiceCard({ service, onSelect }: ServiceCardProps) {
   const handleQuickLaunch = (e: React.MouseEvent) => {
     e.stopPropagation()
-    const url = isMobile() && service.mobileUrl ? service.mobileUrl : service.url
-    window.open(url, '_blank', 'noopener,noreferrer')
+    window.open(service.url, '_blank', 'noopener,noreferrer')
   }
 
   return (
@@ -39,6 +37,7 @@ export default function ServiceCard({ service, onSelect }: ServiceCardProps) {
         {service.name}
       </h3>
       <p className="text-xs text-butler-400 mt-1">{service.description}</p>
+      <p className="text-xs text-butler-500 mt-1 font-mono truncate">{service.url.replace(/^https?:\/\//, '')}</p>
 
       {service.status && (
         <div className="flex items-center gap-1 mt-2">

--- a/app/src/components/services/ServiceDetail.tsx
+++ b/app/src/components/services/ServiceDetail.tsx
@@ -3,7 +3,6 @@ import { useNavigate } from 'react-router-dom'
 import type { Service } from '../../types/services'
 import type { ServiceCredential } from '../../types/user'
 import { SERVICE_DISPLAY_NAMES } from '../../types/user'
-import { isMobile } from '../../utils/device'
 
 interface ServiceDetailProps {
   service: Service
@@ -44,8 +43,7 @@ export default function ServiceDetail({ service, credentials, onClose }: Service
     : null
 
   const handleOpen = () => {
-    const url = isMobile() && service.mobileUrl ? service.mobileUrl : service.url
-    window.open(url, '_blank', 'noopener,noreferrer')
+    window.open(service.url, '_blank', 'noopener,noreferrer')
   }
 
   return (
@@ -90,6 +88,20 @@ export default function ServiceDetail({ service, credentials, onClose }: Service
         </div>
 
         <div className="p-5 space-y-5">
+          {/* URL display */}
+          <div className="flex items-center gap-2 p-3 bg-butler-800 rounded-lg">
+            <span className="font-mono text-sm text-butler-300 truncate flex-1">{service.url}</span>
+            <button
+              onClick={() => navigator.clipboard.writeText(service.url)}
+              className="shrink-0 p-1.5 rounded-md text-butler-500 hover:text-accent hover:bg-butler-700 transition-colors"
+              title="Copy URL"
+            >
+              <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                <path strokeLinecap="round" strokeLinejoin="round" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
+              </svg>
+            </button>
+          </div>
+
           {/* Open button */}
           <button
             onClick={handleOpen}

--- a/app/src/config/services.ts
+++ b/app/src/config/services.ts
@@ -16,25 +16,28 @@ const SERVICE_NAME_MAP: Record<string, string> = {
   'seerr': 'seerr',
 }
 
-// Optional: set VITE_SERVICE_HOSTNAME for Cloudflare Tunnel/remote access
+// Optional: set VITE_SERVICE_HOSTNAME for Cloudflare Tunnel/remote access,
+// or override individual services with VITE_<SERVICE>_URL.
 // e.g. VITE_SERVICE_HOSTNAME=home.yourdomain.com
 const HOSTNAME = import.meta.env.VITE_SERVICE_HOSTNAME || ''
 
-function serviceUrl(envVar: string, port: number, localDefault: string): string {
+function serviceUrl(envVar: string, port: number): string {
   const explicit = import.meta.env[envVar]
   if (explicit) return explicit
   if (HOSTNAME) return `http://${HOSTNAME}:${port}`
-  return localDefault
+  // Fall back to current hostname — works on LAN without any config
+  const host = typeof window !== 'undefined' ? window.location.hostname : 'localhost'
+  return `http://${host}:${port}`
 }
 
 // Pre-compute service URLs so guide text can reference them
-const jellyfinUrl = serviceUrl('VITE_JELLYFIN_URL', 8096, 'http://jellyfin.local')
-const audiobookshelfUrl = serviceUrl('VITE_AUDIOBOOKSHELF_URL', 13378, 'http://audiobooks.local')
-const shelfarrUrl = serviceUrl('VITE_SHELFARR_URL', 5056, 'http://shelfarr.local')
-const immichUrl = serviceUrl('VITE_IMMICH_URL', 2283, 'http://photos.local')
-const nextcloudUrl = serviceUrl('VITE_NEXTCLOUD_URL', 80, 'http://files.local')
-const homeAssistantUrl = serviceUrl('VITE_HOMEASSISTANT_URL', 8123, 'http://ha.local')
-const seerrUrl = serviceUrl('VITE_SEERR_URL', 5055, 'http://requests.local')
+const jellyfinUrl = serviceUrl('VITE_JELLYFIN_URL', 8096)
+const audiobookshelfUrl = serviceUrl('VITE_AUDIOBOOKSHELF_URL', 13378)
+const shelfarrUrl = serviceUrl('VITE_SHELFARR_URL', 5056)
+const immichUrl = serviceUrl('VITE_IMMICH_URL', 2283)
+const nextcloudUrl = serviceUrl('VITE_NEXTCLOUD_URL', 8080)
+const homeAssistantUrl = serviceUrl('VITE_HOMEASSISTANT_URL', 8123)
+const seerrUrl = serviceUrl('VITE_SEERR_URL', 5055)
 
 export const services: Service[] = [
   {


### PR DESCRIPTION
## Summary
- Auto-detect service URLs from browser hostname on LAN (no config needed)
- Remove isMobile() deep link logic that opened broken protocol URLs like `jellyfin://`
- Add URL display with copy button in service detail panel
- Fix Nextcloud port mapping (8080) and update all tunnel documentation
- Supports Cloudflare Tunnel subdomains via build-time env vars

## Changes
- **ServiceCard & ServiceDetail**: Always open web URLs instead of deep links
- **services.ts**: Use `window.location.hostname` as fallback instead of `.local` placeholders
- **README & .env.example**: Document Cloudflare Tunnel URL configuration for remote access

Closes #175