### PR TITLE
Integrate Seerr for media request management

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,7 +101,7 @@ The Mac Mini is set up and all Docker stacks are deployed via OrbStack. Active w
 ### Deployed Stacks
 | Stack | Services | Status |
 |-------|----------|--------|
-| **media-stack** | Jellyfin, Radarr, Sonarr, Bazarr | Running |
+| **media-stack** | Jellyfin, Radarr, Sonarr, Bazarr, Seerr | Running |
 | **download-stack** | qBittorrent, Prowlarr | Running |
 | **books-stack** | Calibre-Web, Audiobookshelf | Running |
 | **photos-files-stack** | Immich, PostgreSQL, Redis, Nextcloud | Running |
@@ -136,7 +136,7 @@ home-server/
 ├── docker/                # Docker Compose stacks
 │   ├── books-stack/       # Calibre-Web, Audiobookshelf
 │   ├── download-stack/    # qBittorrent, Prowlarr
-│   ├── media-stack/       # Jellyfin, Radarr, Sonarr, Bazarr
+│   ├── media-stack/       # Jellyfin, Radarr, Sonarr, Bazarr, Seerr
 │   ├── messaging-stack/   # WhatsApp gateway
 │   ├── photos-files-stack/# Immich, Nextcloud, PostgreSQL
 │   ├── smart-home-stack/  # Home Assistant, Cloudflare Tunnel

--- a/HOMESERVER_PLAN.md
+++ b/HOMESERVER_PLAN.md
@@ -34,7 +34,7 @@
 │  │  │ Jellyfin │ │  Radarr  │ │  Sonarr  │ │ Prowlarr │ │  Bazarr  │  │   │
 │  │  └──────────┘ └──────────┘ └──────────┘ └──────────┘ └──────────┘  │   │
 │  │  ┌──────────┐ ┌──────────┐ ┌──────────┐ ┌──────────┐ ┌──────────┐  │   │
-│  │  │ Shelfarr │ │qBittorrent│ │  Immich  │ │Nextcloud │ │   Home   │  │   │
+│  │  │  Seerr   │ │qBittorrent│ │  Immich  │ │Nextcloud │ │   Home   │  │   │
 │  │  │          │ │          │ │          │ │          │ │Assistant │  │   │
 │  │  └──────────┘ └──────────┘ └──────────┘ └──────────┘ └──────────┘  │   │
 │  │  ┌──────────┐ ┌──────────┐ ┌───────────────────────────────────┐   │   │
@@ -143,6 +143,7 @@
 | [**Radarr**](https://radarr.video/) | [radarr.video](https://radarr.video/) | Movie automation & management | Docker container | 300MB | 500MB | 7878 |
 | [**Sonarr**](https://sonarr.tv/) | [sonarr.tv](https://sonarr.tv/) | TV series automation & management | Docker container | 300MB | 500MB | 8989 |
 | [**Bazarr**](https://www.bazarr.media/) | [bazarr.media](https://www.bazarr.media/) | Subtitle automation | Docker container | 200MB | 400MB | 6767 |
+| [**Seerr**](https://github.com/seerr-team/seerr) | [docs.seerr.dev](https://docs.seerr.dev/) | Media request management | Docker container | 100MB | 200MB | 5055 |
 
 > *Jellyfin peaks during 4K transcoding. Direct play uses minimal resources.
 
@@ -197,14 +198,14 @@
 |----------|----------|------------|------------|
 | **macOS + OrbStack** | System overhead | 3.5GB | 5GB |
 | **Voice Assistant** | LiveKit, Kokoro, Butler API | 1.0GB | 2.1GB |
-| **Media** | Jellyfin, *arrs, qBit | 1.5GB | 5.9GB |
+| **Media** | Jellyfin, *arrs, Seerr, qBit | 1.6GB | 6.1GB |
 | **Photos/Files** | Immich, Nextcloud | 1.4GB | 5GB |
 | **Books** | Audiobookshelf, Shelfarr | 0.35GB | 0.7GB |
 | **Smart Home** | Home Assistant | 0.4GB | 1GB |
 | **Notifications** | WhatsApp | 0.1GB | 0.2GB |
 | | | | |
-| **TOTAL** | | **8.75GB** | **21.4GB** |
-| **Available** | 24GB | **15.25GB free** | **2.6GB free** |
+| **TOTAL** | | **8.85GB** | **21.6GB** |
+| **Available** | 24GB | **15.15GB free** | **2.4GB free** |
 
 ### Voice Assistant RAM Breakdown
 
@@ -1215,6 +1216,7 @@ This does NOT protect against: Mac Mini theft/fire (use cloud for that).
 | 7880 | LiveKit | LAN + Cloudflare Tunnel |
 | 7878 | Radarr | LAN only |
 | 8989 | Sonarr | LAN only |
+| 5055 | Seerr | LAN + Cloudflare Tunnel |
 | 6767 | Bazarr | LAN only |
 | 9696 | Prowlarr | LAN only |
 | 8081 | qBittorrent | LAN only |

--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ Decide which services you want accessible remotely. Example mapping:
 | `files.yourdomain.com` | Nextcloud | 8080 |
 | `ha.yourdomain.com` | Home Assistant | 8123 |
 | `shelfarr.yourdomain.com` | Shelfarr | 5056 |
+| `requests.yourdomain.com` | Seerr | 5055 |
 
 You'll configure these routes in the Cloudflare dashboard after `setup.sh` has deployed the services.
 
@@ -233,7 +234,7 @@ cd ~/home-server && ./scripts/change-drive.sh
 | 4 | `05-orbstack.sh` | OrbStack (Docker) |
 | 5 | `06-external-drive.sh` | External drive directory structure |
 | 6 | `07-download-stack.sh` | qBittorrent + Prowlarr |
-| 7 | `08-media-stack.sh` | Jellyfin + Radarr + Sonarr + Bazarr |
+| 7 | `08-media-stack.sh` | Jellyfin + Radarr + Sonarr + Bazarr + Seerr |
 | 8 | `09-books-stack.sh` | Audiobookshelf + Shelfarr |
 | 9 | `10-photos-files.sh` | Immich + Nextcloud |
 | 10 | `11-smart-home.sh` | Home Assistant + Cloudflare Tunnel |
@@ -275,6 +276,7 @@ Now that services are running, go back to the Cloudflare dashboard and add route
 | `files` | `http://nextcloud:80` | Nextcloud |
 | `ha` | `http://homeassistant:8123` | Home Assistant |
 | `shelfarr` | `http://shelfarr:5056` | Shelfarr |
+| `requests` | `http://seerr:5055` | Seerr |
 
 > **Important:** Use Docker container names (not `localhost`) because `cloudflared` runs inside Docker where `localhost` refers to the container itself, not the host machine.
 
@@ -299,8 +301,9 @@ Butler uses **invite codes** for registration. The first person to log in become
 | **Prowlarr** | `http://<server-ip>:9696` | Auto-configured with public indexers — optionally add private indexers ([guide](docs/prowlarr-indexers.md)) |
 | **qBittorrent** | `http://<server-ip>:8081` | Auto-configured — check container logs for temp password if needed |
 | **Bazarr** | `http://<server-ip>:6767` | Auto-configured — connected to Radarr + Sonarr |
+| **Seerr** | `http://<server-ip>:5055` | Complete setup wizard — sign in with Jellyfin, connect Radarr + Sonarr |
 
-> Radarr, Sonarr, Prowlarr, and qBittorrent are admin-only. Household members interact with media through Jellyfin.
+> Radarr, Sonarr, Prowlarr, and qBittorrent are admin-only. Household members request media through Seerr and watch via Jellyfin.
 
 ### 4.4 Set Up Books & Audio
 
@@ -412,6 +415,7 @@ docker compose down && docker compose up -d
 | [Radarr](https://radarr.video/) | Movie automation | 7878 |
 | [Sonarr](https://sonarr.tv/) | TV series automation | 8989 |
 | [Bazarr](https://www.bazarr.media/) | Subtitle automation | 6767 |
+| [Seerr](https://github.com/seerr-team/seerr) | Media request management | 5055 |
 | [Prowlarr](https://prowlarr.com/) | Indexer manager | 9696 |
 | [qBittorrent](https://www.qbittorrent.org/) | Torrent client | 8081 |
 

--- a/app/.env.example
+++ b/app/.env.example
@@ -10,3 +10,4 @@ VITE_LIVEKIT_URL=ws://localhost:7880
 # VITE_IMMICH_URL=http://photos.local:2283
 # VITE_NEXTCLOUD_URL=http://files.local
 # VITE_HOMEASSISTANT_URL=http://ha.local:8123
+# VITE_SEERR_URL=http://requests.local:5055

--- a/app/src/config/services.ts
+++ b/app/src/config/services.ts
@@ -13,6 +13,7 @@ const SERVICE_NAME_MAP: Record<string, string> = {
   'immich-server': 'immich',
   'nextcloud': 'nextcloud',
   'homeassistant': 'home-assistant',
+  'seerr': 'seerr',
 }
 
 // Optional: set VITE_SERVICE_HOSTNAME for Cloudflare Tunnel/remote access
@@ -33,6 +34,7 @@ const shelfarrUrl = serviceUrl('VITE_SHELFARR_URL', 5056, 'http://shelfarr.local
 const immichUrl = serviceUrl('VITE_IMMICH_URL', 2283, 'http://photos.local')
 const nextcloudUrl = serviceUrl('VITE_NEXTCLOUD_URL', 80, 'http://files.local')
 const homeAssistantUrl = serviceUrl('VITE_HOMEASSISTANT_URL', 8123, 'http://ha.local')
+const seerrUrl = serviceUrl('VITE_SEERR_URL', 5055, 'http://requests.local')
 
 export const services: Service[] = [
   {
@@ -59,6 +61,29 @@ export const services: Service[] = [
       tips: [
         'Use the mobile app for the best experience — it supports offline downloads and background audio',
         'To request new movies or shows, just ask Butler in the chat',
+      ],
+    },
+  },
+  {
+    id: 'seerr',
+    name: 'Seerr',
+    description: 'Media Requests',
+    icon: '🎬',
+    url: seerrUrl,
+    category: 'media',
+    guide: {
+      whatItDoes: 'Request movies and TV shows for the household. Approved requests are sent to Radarr and Sonarr automatically.',
+      steps: [
+        'Open Seerr in your browser or on your phone',
+        'Search for a movie or TV show you want to watch',
+        'Click "Request" and choose the quality/seasons you want',
+        'Your request will be approved automatically or queued for admin review',
+        'Once approved, the media downloads and appears in Jellyfin',
+      ],
+      tips: [
+        'You can also ask Butler to request media — just say "request the new Batman movie"',
+        'Check the request list to see the status of your pending requests',
+        'Already-available titles are marked so you can watch them right away in Jellyfin',
       ],
     },
   },

--- a/butler/.env.example
+++ b/butler/.env.example
@@ -118,6 +118,16 @@ RADARR_URL=http://radarr:7878
 RADARR_API_KEY=
 
 # ===================
+# Seerr (optional — for media request management)
+# ===================
+
+# Seerr server URL (container name on homeserver Docker network)
+SEERR_URL=http://seerr:5055
+
+# API key from Seerr: Settings > General > API Key
+SEERR_API_KEY=
+
+# ===================
 # Sonarr (optional — for TV series library management)
 # ===================
 

--- a/butler/api/config.py
+++ b/butler/api/config.py
@@ -53,6 +53,11 @@ class Settings(BaseSettings):
     radarr_url: str = ""
     radarr_api_key: str = ""
 
+    # Seerr (media request management)
+    seerr_url: str = ""
+    seerr_api_key: str = ""
+
+
     # Sonarr (TV series management)
     sonarr_url: str = ""
     sonarr_api_key: str = ""

--- a/butler/api/deps.py
+++ b/butler/api/deps.py
@@ -25,6 +25,7 @@ from tools import (
     MediaFilesTool,
     PhoneLocationTool,
     RadarrTool,
+    SeerrTool,
     RecallFactsTool,
     RememberFactTool,
     GetUserTool,
@@ -59,7 +60,7 @@ ALWAYS_ALLOWED_TOOLS: set[str] = {
 }
 
 PERMISSION_TOOL_MAP: dict[str, list[str]] = {
-    "media": ["radarr", "books", "sonarr", "immich", "jellyfin", "media_files"],
+    "media": ["radarr", "seerr", "books", "sonarr", "immich", "jellyfin", "media_files"],
     "home": ["home_assistant", "list_ha_entities"],
     "location": ["phone_location"],
     "calendar": ["google_calendar"],
@@ -120,6 +121,13 @@ async def init_resources() -> None:
         _tools["radarr"] = RadarrTool(
             base_url=settings.radarr_url,
             api_key=settings.radarr_api_key,
+        )
+
+    # Only register Seerr tool if configured
+    if settings.seerr_url:
+        _tools["seerr"] = SeerrTool(
+            base_url=settings.seerr_url,
+            api_key=settings.seerr_api_key,
         )
 
     # Books tool (Open Library + Prowlarr + qBittorrent)

--- a/butler/api/llm.py
+++ b/butler/api/llm.py
@@ -86,7 +86,7 @@ def _build_tool_definitions(tools: dict[str, Tool]) -> list[dict]:
 ROUTING_CORE_TOOLS: set[str] = {
     "remember_fact", "recall_facts", "get_user",
     "weather", "display_in_chat",
-    "radarr", "books", "sonarr",
+    "radarr", "seerr", "books", "sonarr",
 }
 
 # Only enable routing when there are this many non-core tools.

--- a/butler/tools/__init__.py
+++ b/butler/tools/__init__.py
@@ -33,6 +33,7 @@ from .gmail import GmailTool
 from .google_calendar import GoogleCalendarTool
 from .jellyfin import JellyfinTool
 from .radarr import RadarrTool
+from .seerr import SeerrTool
 from .books import BookTool
 from .sonarr import SonarrTool
 from .immich import ImmichTool
@@ -75,6 +76,8 @@ __all__ = [
     "PhoneLocationTool",
     # Radarr
     "RadarrTool",
+    # Seerr
+    "SeerrTool",
     # Books (Open Library + Prowlarr + qBittorrent)
     "BookTool",
     # Sonarr

--- a/butler/tools/seerr.py
+++ b/butler/tools/seerr.py
@@ -1,0 +1,394 @@
+"""Seerr integration tool for Butler.
+
+This tool allows the agent to search for and request movies/TV shows via
+Seerr's REST API, enabling voice and text-based media request management.
+
+Usage:
+    The tool is automatically registered when SEERR_URL is configured.
+    Requires SEERR_URL and SEERR_API_KEY in the application settings.
+
+Example:
+    tool = SeerrTool(base_url="http://seerr:5055", api_key="abc123")
+    result = await tool.execute(action="search", query="Inception")
+
+    # When shutting down
+    await tool.close()
+
+API Reference:
+    Seerr API docs available at http://<host>:5055/api-docs
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import aiohttp
+
+from .base import Tool
+
+DEFAULT_TIMEOUT = 30
+
+
+class SeerrTool(Tool):
+    """Search for and request movies/TV shows via Seerr.
+
+    Supports searching for media, creating requests, listing pending
+    requests, and checking request status. Seerr routes movie requests
+    to Radarr and TV requests to Sonarr automatically.
+    """
+
+    def __init__(
+        self,
+        base_url: str | None = None,
+        api_key: str | None = None,
+        timeout: int = DEFAULT_TIMEOUT,
+    ):
+        self.base_url = (base_url or "").rstrip("/")
+        self.api_key = api_key or ""
+        self.timeout = aiohttp.ClientTimeout(total=timeout)
+        self._session: aiohttp.ClientSession | None = None
+
+    async def _get_session(self) -> aiohttp.ClientSession:
+        if self._session is None or self._session.closed:
+            self._session = aiohttp.ClientSession(
+                headers={"X-Api-Key": self.api_key},
+                timeout=self.timeout,
+            )
+        return self._session
+
+    async def close(self) -> None:
+        if self._session and not self._session.closed:
+            await self._session.close()
+            self._session = None
+
+    # -- Tool interface -------------------------------------------------------
+
+    @property
+    def name(self) -> str:
+        return "seerr"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Search for movies and TV shows, request them for download, "
+            "and check the status of pending requests via Seerr. "
+            "Requests are automatically routed to Radarr (movies) or Sonarr (TV)."
+        )
+
+    @property
+    def parameters(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "action": {
+                    "type": "string",
+                    "enum": [
+                        "search",
+                        "request_movie",
+                        "request_tv",
+                        "get_requests",
+                        "get_movie",
+                        "get_tv",
+                    ],
+                    "description": (
+                        "search: Find movies/TV on TMDB via Seerr. "
+                        "request_movie: Request a movie (needs tmdb_id from search). "
+                        "request_tv: Request a TV show (needs tmdb_id from search). "
+                        "get_requests: List pending/approved/available requests. "
+                        "get_movie: Get details and availability for a movie. "
+                        "get_tv: Get details and availability for a TV show."
+                    ),
+                },
+                "query": {
+                    "type": "string",
+                    "description": "Search query for finding movies or TV shows.",
+                },
+                "tmdb_id": {
+                    "type": "integer",
+                    "description": (
+                        "TMDB ID from search results. "
+                        "Required for request_movie, request_tv, get_movie, get_tv."
+                    ),
+                },
+                "seasons": {
+                    "type": "array",
+                    "items": {"type": "integer"},
+                    "description": (
+                        "Season numbers to request for TV shows. "
+                        "If omitted, requests all available seasons."
+                    ),
+                },
+            },
+            "required": ["action"],
+        }
+
+    async def execute(self, **kwargs: Any) -> str:
+        action = kwargs["action"]
+
+        if not self.base_url or not self.api_key:
+            return "Error: SEERR_URL and SEERR_API_KEY must be configured."
+
+        try:
+            if action == "search":
+                return await self._search(kwargs.get("query", ""))
+            elif action == "request_movie":
+                return await self._request_movie(kwargs.get("tmdb_id"))
+            elif action == "request_tv":
+                return await self._request_tv(
+                    kwargs.get("tmdb_id"), kwargs.get("seasons"),
+                )
+            elif action == "get_requests":
+                return await self._get_requests()
+            elif action == "get_movie":
+                return await self._get_movie(kwargs.get("tmdb_id"))
+            elif action == "get_tv":
+                return await self._get_tv(kwargs.get("tmdb_id"))
+            else:
+                return f"Error: Unknown action '{action}'"
+        except aiohttp.ClientError as e:
+            return f"Error connecting to Seerr: {e}"
+        except TimeoutError:
+            return "Error: Seerr request timed out"
+        except Exception as e:
+            return f"Error: {e}"
+
+    # -- Actions --------------------------------------------------------------
+
+    async def _search(self, query: str) -> str:
+        if not query:
+            return "Error: query is required for search"
+
+        session = await self._get_session()
+        url = f"{self.base_url}/api/v1/search"
+
+        async with session.get(url, params={"query": query, "page": 1}) as resp:
+            if resp.status == 401:
+                return "Error: Invalid Seerr API key."
+            if resp.status != 200:
+                return f"Error: HTTP {resp.status}"
+
+            data = await resp.json()
+
+        results = data.get("results", [])
+        if not results:
+            return f"No results found for '{query}'"
+
+        return self._format_search_results(results[:8], query)
+
+    async def _request_movie(self, tmdb_id: int | None) -> str:
+        if not tmdb_id:
+            return "Error: tmdb_id is required (get it from search)"
+
+        session = await self._get_session()
+        url = f"{self.base_url}/api/v1/request"
+        payload = {"mediaType": "movie", "mediaId": tmdb_id}
+
+        async with session.post(url, json=payload) as resp:
+            if resp.status in (200, 201):
+                result = await resp.json()
+                status = result.get("status", "unknown")
+                media = result.get("media", {})
+                title = media.get("title", f"TMDB:{tmdb_id}")
+                status_text = {
+                    1: "pending approval",
+                    2: "approved",
+                    3: "declined",
+                }.get(status, f"status {status}")
+                return f"Requested movie '{title}' — {status_text}. Seerr will route to Radarr."
+            elif resp.status == 409:
+                return "This movie has already been requested."
+            else:
+                body = await resp.text()
+                return f"Error requesting movie: HTTP {resp.status} — {body[:200]}"
+
+    async def _request_tv(
+        self, tmdb_id: int | None, seasons: list[int] | None,
+    ) -> str:
+        if not tmdb_id:
+            return "Error: tmdb_id is required (get it from search)"
+
+        session = await self._get_session()
+        url = f"{self.base_url}/api/v1/request"
+        payload: dict[str, Any] = {"mediaType": "tv", "mediaId": tmdb_id}
+        if seasons:
+            payload["seasons"] = seasons
+
+        async with session.post(url, json=payload) as resp:
+            if resp.status in (200, 201):
+                result = await resp.json()
+                status = result.get("status", "unknown")
+                status_text = {
+                    1: "pending approval",
+                    2: "approved",
+                    3: "declined",
+                }.get(status, f"status {status}")
+                season_note = f" (seasons {seasons})" if seasons else " (all seasons)"
+                return f"Requested TV show (TMDB:{tmdb_id}){season_note} — {status_text}. Seerr will route to Sonarr."
+            elif resp.status == 409:
+                return "This TV show has already been requested."
+            else:
+                body = await resp.text()
+                return f"Error requesting TV show: HTTP {resp.status} — {body[:200]}"
+
+    async def _get_requests(self) -> str:
+        session = await self._get_session()
+        url = f"{self.base_url}/api/v1/request"
+
+        async with session.get(url, params={"take": 20, "skip": 0, "sort": "added"}) as resp:
+            if resp.status == 401:
+                return "Error: Invalid Seerr API key."
+            if resp.status != 200:
+                return f"Error: HTTP {resp.status}"
+
+            data = await resp.json()
+
+        results = data.get("results", [])
+        if not results:
+            return "No media requests found."
+
+        return self._format_requests(results)
+
+    async def _get_movie(self, tmdb_id: int | None) -> str:
+        if not tmdb_id:
+            return "Error: tmdb_id is required"
+
+        session = await self._get_session()
+        url = f"{self.base_url}/api/v1/movies/{tmdb_id}"
+
+        async with session.get(url) as resp:
+            if resp.status == 404:
+                return f"Movie with TMDB ID {tmdb_id} not found."
+            if resp.status != 200:
+                return f"Error: HTTP {resp.status}"
+
+            movie = await resp.json()
+
+        return self._format_movie_detail(movie)
+
+    async def _get_tv(self, tmdb_id: int | None) -> str:
+        if not tmdb_id:
+            return "Error: tmdb_id is required"
+
+        session = await self._get_session()
+        url = f"{self.base_url}/api/v1/tv/{tmdb_id}"
+
+        async with session.get(url) as resp:
+            if resp.status == 404:
+                return f"TV show with TMDB ID {tmdb_id} not found."
+            if resp.status != 200:
+                return f"Error: HTTP {resp.status}"
+
+            show = await resp.json()
+
+        return self._format_tv_detail(show)
+
+    # -- Formatting -----------------------------------------------------------
+
+    def _format_search_results(self, results: list[dict], query: str) -> str:
+        lines = [f"Found {len(results)} result(s) for '{query}':\n"]
+        for i, item in enumerate(results, 1):
+            media_type = item.get("mediaType", "unknown")
+            tmdb_id = item.get("id", "?")
+            overview = item.get("overview", "")
+            if len(overview) > 120:
+                overview = overview[:120] + "..."
+
+            if media_type == "movie":
+                title = item.get("title", "Unknown")
+                year = item.get("releaseDate", "")[:4]
+                lines.append(f"{i}. [Movie] {title} ({year}) [TMDB: {tmdb_id}]")
+            elif media_type == "tv":
+                title = item.get("name", "Unknown")
+                year = item.get("firstAirDate", "")[:4]
+                lines.append(f"{i}. [TV] {title} ({year}) [TMDB: {tmdb_id}]")
+            else:
+                name = item.get("name") or item.get("title", "Unknown")
+                lines.append(f"{i}. [{media_type}] {name} [ID: {tmdb_id}]")
+
+            # Show availability status if present
+            media_info = item.get("mediaInfo")
+            if media_info:
+                status = media_info.get("status")
+                status_text = {
+                    1: "unknown",
+                    2: "pending",
+                    3: "processing",
+                    4: "partially available",
+                    5: "available",
+                }.get(status, "")
+                if status_text:
+                    lines.append(f"   Status: {status_text}")
+
+            if overview:
+                lines.append(f"   {overview}")
+        return "\n".join(lines)
+
+    def _format_requests(self, requests: list[dict]) -> str:
+        status_map = {1: "Pending", 2: "Approved", 3: "Declined"}
+        lines = [f"Media Requests ({len(requests)}):\n"]
+        for req in requests:
+            req_id = req.get("id", "?")
+            media_type = req.get("type", req.get("media", {}).get("mediaType", "?"))
+            status = status_map.get(req.get("status", 0), "Unknown")
+            media = req.get("media", {})
+            tmdb_id = media.get("tmdbId", "?")
+
+            # Requester info
+            requester = req.get("requestedBy", {})
+            user_name = requester.get("displayName", requester.get("username", "?"))
+
+            lines.append(f"- #{req_id}: [{media_type}] TMDB:{tmdb_id} — {status} (by {user_name})")
+
+        return "\n".join(lines)
+
+    def _format_movie_detail(self, movie: dict) -> str:
+        title = movie.get("title", "Unknown")
+        year = movie.get("releaseDate", "")[:4]
+        overview = movie.get("overview", "")
+        if len(overview) > 200:
+            overview = overview[:200] + "..."
+        runtime = movie.get("runtime", 0)
+
+        media_info = movie.get("mediaInfo")
+        if media_info:
+            status = media_info.get("status", 1)
+            status_text = {
+                1: "Unknown", 2: "Pending", 3: "Processing",
+                4: "Partially Available", 5: "Available",
+            }.get(status, "Unknown")
+        else:
+            status_text = "Not Requested"
+
+        lines = [
+            f"{title} ({year})",
+            f"  Runtime: {runtime} min" if runtime else "",
+            f"  Status: {status_text}",
+            f"  {overview}" if overview else "",
+        ]
+        return "\n".join(line for line in lines if line)
+
+    def _format_tv_detail(self, show: dict) -> str:
+        title = show.get("name", "Unknown")
+        year = show.get("firstAirDate", "")[:4]
+        overview = show.get("overview", "")
+        if len(overview) > 200:
+            overview = overview[:200] + "..."
+        seasons_count = show.get("numberOfSeasons", 0)
+
+        media_info = show.get("mediaInfo")
+        if media_info:
+            status = media_info.get("status", 1)
+            status_text = {
+                1: "Unknown", 2: "Pending", 3: "Processing",
+                4: "Partially Available", 5: "Available",
+            }.get(status, "Unknown")
+        else:
+            status_text = "Not Requested"
+
+        lines = [
+            f"{title} ({year})",
+            f"  Seasons: {seasons_count}" if seasons_count else "",
+            f"  Status: {status_text}",
+            f"  {overview}" if overview else "",
+        ]
+        return "\n".join(line for line in lines if line)

--- a/butler/tools/server_health.py
+++ b/butler/tools/server_health.py
@@ -58,6 +58,10 @@ DEFAULT_SERVICES: dict[str, dict[str, Any]] = {
         "url": "http://bazarr:6767/",
         "stack": "media",
     },
+    "seerr": {
+        "url": "http://seerr:5055/api/v1/status",
+        "stack": "media",
+    },
     # Download stack
     "qbittorrent": {
         "url": "http://qbittorrent:8081/",

--- a/docker/media-stack/docker-compose.yml
+++ b/docker/media-stack/docker-compose.yml
@@ -99,6 +99,25 @@ services:
       retries: 3
       start_period: 30s
 
+  seerr:
+    image: seerr/seerr:develop
+    container_name: seerr
+    environment:
+      - TZ=Europe/London
+    volumes:
+      - seerr-config:/app/config
+    ports:
+      - "5055:5055"
+    networks:
+      - homeserver
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "http://127.0.0.1:5055/api/v1/status"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
+
 networks:
   homeserver:
     external: true
@@ -114,3 +133,5 @@ volumes:
     name: sonarr-config
   bazarr-config:
     name: bazarr-config
+  seerr-config:
+    name: seerr-config

--- a/docs/08-media-stack.md
+++ b/docs/08-media-stack.md
@@ -1,6 +1,6 @@
 # Step 8: Deploy Media Stack
 
-Deploy Jellyfin (media server) and the *arr apps for movie/TV automation.
+Deploy Jellyfin (media server), the *arr apps for movie/TV automation, and Seerr for media requests.
 
 ## Automated
 
@@ -31,6 +31,7 @@ docker compose ps
 | Radarr | http://localhost:7878 | Movie automation |
 | Sonarr | http://localhost:8989 | TV series automation |
 | Bazarr | http://localhost:6767 | Subtitle automation |
+| Seerr | http://localhost:5055 | Media request management |
 
 ## Initial Configuration
 
@@ -91,6 +92,21 @@ docker compose ps
 5. **Settings > Languages:**
    - Configure preferred subtitle languages
 
+### Seerr
+
+1. Open http://localhost:5055
+2. Sign in with your Jellyfin admin account
+3. **Radarr Settings:**
+   - Host: `radarr`
+   - Port: `7878`
+   - API Key: (from Radarr Settings > General)
+4. **Sonarr Settings:**
+   - Host: `sonarr`
+   - Port: `8989`
+   - API Key: (from Sonarr Settings > General)
+5. Copy the **API Key** from Settings > General for Butler integration
+6. Optionally enable auto-approval for admin users
+
 ### Connect Prowlarr to *arr Apps
 
 In Prowlarr (http://localhost:9696):
@@ -127,7 +143,11 @@ In Prowlarr (http://localhost:9696):
 ## The Download Flow
 
 ```
-You search in Radarr/Sonarr
+You (or household members) request in Seerr
+        ↓
+Seerr sends to Radarr/Sonarr
+        ↓
+Or you search directly in Radarr/Sonarr
         ↓
 Prowlarr provides indexers
         ↓

--- a/scripts/08-media-stack.sh
+++ b/scripts/08-media-stack.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Step 8: Deploy Media Stack (Jellyfin + Radarr + Sonarr + Bazarr)
+# Step 8: Deploy Media Stack (Jellyfin + Radarr + Sonarr + Bazarr + Seerr)
 set -e
 
 GREEN='\033[0;32m'
@@ -323,6 +323,35 @@ with open('/config/config/config.yaml', 'w') as f:
         || echo -e "  ${YELLOW}⚠${NC} Bazarr connection may need manual setup at http://localhost:6767"
 else
     echo -e "  ${YELLOW}⚠${NC} Missing API keys — configure Bazarr manually at http://localhost:6767"
+fi
+
+# ─────────────────────────────────────────────
+# Seerr: Post-deploy info
+# (Seerr requires a web-based setup wizard on first run — cannot be
+# fully automated via API. Print instructions for the user.)
+# ─────────────────────────────────────────────
+echo ""
+echo -e "${BLUE}==>${NC} Seerr setup..."
+
+# Wait for Seerr to respond
+SEERR_READY=false
+for i in {1..15}; do
+    if curl -sf http://localhost:5055/api/v1/status &>/dev/null; then
+        SEERR_READY=true
+        break
+    fi
+    sleep 2
+done
+
+if $SEERR_READY; then
+    echo -e "  ${GREEN}✓${NC} Seerr is running at http://localhost:5055"
+    echo -e "  ${YELLOW}⚠${NC} Complete the setup wizard in your browser:"
+    echo -e "     1. Open http://localhost:5055"
+    echo -e "     2. Sign in with your Jellyfin account"
+    echo -e "     3. Connect Radarr (http://radarr:7878) and Sonarr (http://sonarr:8989)"
+    echo -e "     4. Copy the API key from Settings > General for Butler integration"
+else
+    echo -e "  ${YELLOW}⚠${NC} Seerr may still be starting — configure at http://localhost:5055"
 fi
 
 # ─────────────────────────────────────────────

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -29,6 +29,7 @@ CONFIG_VOLUMES=(
     radarr-config
     sonarr-config
     bazarr-config
+    seerr-config
     audiobookshelf-config
     audiobookshelf-metadata
     prowlarr-config

--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -24,6 +24,7 @@ declare -A VOLUME_CONTAINER=(
     [radarr-config]=radarr
     [sonarr-config]=sonarr
     [bazarr-config]=bazarr
+    [seerr-config]=seerr
     [audiobookshelf-config]=audiobookshelf
     [audiobookshelf-metadata]=audiobookshelf
     [prowlarr-config]=prowlarr


### PR DESCRIPTION
## Summary

Add Seerr (media request manager) to enable household members to request movies and TV shows through a user-friendly interface instead of accessing Radarr/Sonarr admin panels directly. Includes full Docker deployment, Butler AI integration for voice commands, PWA service card, and complete documentation.

## Implementation

- **Docker**: Added seerr service (port 5055) with health check and persistent config volume
- **Butler Tool**: Created SeerrTool with search, request_movie, request_tv, get_requests, and get_movie/get_tv operations
- **Butler Integration**: Registered tool in core routing, media permissions, health monitoring, and config
- **PWA**: Added Seerr service card showing how to request media (visible in UI alongside other services)
- **Setup Automation**: Added Seerr post-deploy configuration checks and user instructions
- **Data Protection**: Updated backup/restore scripts to include seerr-config volume
- **Documentation**: Updated README (deployment table, tunnel routes, setup checklist), HOMESERVER_PLAN (services table, resource budget, port map), media-stack guide, and CLAUDE.md

## Architecture

Seerr sits between end users and the download pipeline:
- Users/household members → Seerr (sign in via Jellyfin) → Request movie/TV
- Seerr → Radarr (movies) or Sonarr (TV) → qBittorrent → Download
- Radarr/Sonarr → Jellyfin → Watch

Butler can fulfill requests via SeerrTool for voice commands: "request the new Batman movie"

## Testing

- [x] Docker compose validates
- [x] Python syntax check for seerr.py
- [x] Tool imports and registration verified
- [x] Configuration documented with examples
- [ ] Deploy on Mac Mini and verify Seerr stack starts (local testing)
- [ ] Verify Seerr → Radarr/Sonarr connection (first-time setup wizard)
- [ ] Test Butler AI request workflow ("request [movie/show name]")

## Related

Closes #176