### PR TITLE
Fix environment variable configuration

### DIFF
--- a/butler/.env.example
+++ b/butler/.env.example
@@ -188,8 +188,32 @@ NEXTCLOUD_ADMIN_PASSWORD=
 CLOUDFLARE_TUNNEL_TOKEN=
 
 # ===================
+# qBittorrent (optional — for download management)
+# ===================
+
+# qBittorrent WebUI URL (container name on homeserver Docker network)
+QBITTORRENT_URL=http://qbittorrent:8081
+
+# WebUI credentials (default: admin / adminadmin)
+QBITTORRENT_USERNAME=admin
+QBITTORRENT_PASSWORD=adminadmin
+
+# ===================
+# Web Push (optional — VAPID keys for PWA push notifications)
+# ===================
+
+# Generate with: npx web-push generate-vapid-keys --json
+# VAPID_PUBLIC_KEY=
+# VAPID_PRIVATE_KEY=
+# VAPID_SUBJECT=mailto:admin@homeserver.local
+
+# ===================
 # Media Files (optional — direct filesystem access to media directories)
 # ===================
+
+# Path to the data directory (external drive or local folder)
+# Used as Docker volume mount and by media_files tool
+DRIVE_PATH=/Volumes/HomeServer
 
 # Enable the media_files tool for browsing/managing files on the external drive
 # Allows listing, searching, renaming, deleting, and quality scanning of media files

--- a/butler/docker-compose.yml
+++ b/butler/docker-compose.yml
@@ -55,6 +55,9 @@ services:
       # Prowlarr
       - PROWLARR_URL=${PROWLARR_URL:-http://prowlarr:9696}
       - PROWLARR_API_KEY=${PROWLARR_API_KEY:-}
+      # Seerr (media request management)
+      - SEERR_URL=${SEERR_URL:-http://seerr:5055}
+      - SEERR_API_KEY=${SEERR_API_KEY:-}
       # Immich (photo management + user provisioning)
       - IMMICH_URL=${IMMICH_URL:-http://immich-server:2283}
       - IMMICH_API_KEY=${IMMICH_API_KEY:-}


### PR DESCRIPTION
## Summary
Fixed butler environment variable configuration by ensuring Seerr integration is properly wired and documentation is complete.

## Changes
- Added `SEERR_URL` and `SEERR_API_KEY` to docker-compose.yml so the Seerr tool receives the variables needed for media request management
- Updated `.env.example` with missing sections: qBittorrent configuration, Web Push (VAPID keys), and DRIVE_PATH documentation
- These variables were already in the `.env` on the server but weren't reaching the butler-api container

## Testing
- Butler-api container restarted and confirmed healthy
- Seerr and VAPID environment variables now present inside container
- All 22 containers running healthy with correct configuration