### PR TITLE
Fix mobile invite permissions and service provisioning visibility

### DIFF
--- a/app/src/pages/Onboarding.tsx
+++ b/app/src/pages/Onboarding.tsx
@@ -84,9 +84,9 @@ export default function Onboarding() {
       // Fetch the complete profile
       await fetchProfile()
 
-      // If service accounts were provisioned and some failed, show results
+      // If service accounts had issues (failed or skipped), show results
       const accounts = response.serviceAccounts || []
-      const hasFailed = accounts.some(a => a.status === 'failed')
+      const hasFailed = accounts.some(a => a.status === 'failed' || a.status === 'skipped')
       if (hasFailed) {
         setProvisioningResults(accounts)
         setIsSubmitting(false)
@@ -383,16 +383,28 @@ export default function Onboarding() {
               {provisioningResults.map(result => {
                 const info = SERVICE_DISPLAY_NAMES[result.service] || { label: result.service, description: '' }
                 const ok = result.status === 'active'
+                const skipped = result.status === 'skipped'
                 return (
-                  <div key={result.service} className="flex items-center justify-between p-3 bg-butler-800 rounded-lg">
-                    <div>
-                      <div className="text-sm text-butler-100">{info.label}</div>
-                      <div className="text-xs text-butler-500">{info.description}</div>
+                  <div key={result.service} className={`p-3 rounded-lg ${
+                    ok ? 'bg-butler-800'
+                      : skipped ? 'bg-butler-800 border border-butler-600'
+                      : 'bg-red-900/20 border border-red-900/40'
+                  }`}>
+                    <div className="flex items-center justify-between">
+                      <div>
+                        <div className="text-sm text-butler-100">{info.label}</div>
+                        <div className="text-xs text-butler-500">{info.description}</div>
+                      </div>
+                      {ok ? (
+                        <span className="text-xs text-green-400">Created</span>
+                      ) : skipped ? (
+                        <span className="text-xs text-yellow-400">Skipped</span>
+                      ) : (
+                        <span className="text-xs text-red-400">Failed</span>
+                      )}
                     </div>
-                    {ok ? (
-                      <span className="text-xs text-green-400">Created</span>
-                    ) : (
-                      <span className="text-xs text-red-400">Failed</span>
+                    {!ok && result.error && (
+                      <p className={`text-xs mt-1.5 ${skipped ? 'text-yellow-400/80' : 'text-red-400/80'}`}>{result.error}</p>
                     )}
                   </div>
                 )

--- a/app/src/pages/Settings.tsx
+++ b/app/src/pages/Settings.tsx
@@ -332,17 +332,17 @@ export default function Settings() {
             <span className="text-butler-600 ml-2 text-xs normal-case">admin</span>
           </h2>
 
-          <div className="mb-4">
-            <p className="text-xs text-butler-500 mb-2">Permissions for new user:</p>
-            <div className="flex flex-wrap gap-2 mb-3">
+          <div className="mb-4 p-3 bg-butler-900 rounded-lg">
+            <p className="text-sm font-medium text-butler-300 mb-2">Permissions for new user</p>
+            <div className="flex flex-wrap gap-2">
               {(Object.keys(PERMISSION_INFO) as ToolPermission[]).map(perm => (
                 <button
                   key={perm}
                   onClick={() => toggleInvitePermission(perm)}
-                  className={`px-2.5 py-1 rounded-full text-xs transition-colors ${
+                  className={`px-3 py-1.5 rounded-full text-xs font-medium transition-colors ${
                     invitePermissions.has(perm)
                       ? 'bg-accent/20 text-accent border border-accent/40'
-                      : 'bg-butler-800 text-butler-500 border border-butler-700'
+                      : 'bg-butler-800 text-butler-400 border border-butler-600'
                   }`}
                 >
                   {PERMISSION_INFO[perm].label}

--- a/butler/api/provisioning.py
+++ b/butler/api/provisioning.py
@@ -84,6 +84,10 @@ async def provision_user_accounts(
     for service in target_services:
         if not _service_is_configured(service):
             logger.info("Skipping %s provisioning (not configured)", service)
+            results.append(
+                {"service": service, "username": username,
+                 "status": "skipped", "error": "Not configured on this server"}
+            )
             continue
 
         # Idempotency check — only skip if already active


### PR DESCRIPTION
## Summary

Fixed three critical issues in the onboarding flow:

1. **Permission toggles invisible on mobile** — Wrapped in a darker panel with better contrast, larger tap targets, and a prominent heading so users can actually see and adjust them

2. **Provisioning errors silent** — Failed services now show error messages; skipped services report "Not configured on this server" instead of vanishing

3. **Missing credentials are opaque** — Users now immediately see which services couldn't be provisioned (e.g., missing HA_TOKEN or JELLYFIN_API_KEY env vars) and why

## What Changed

- Settings.tsx: Permission section now visually distinct with dark background, larger text, better borders
- Onboarding.tsx: Results page shows failed/skipped services with actual error messages and color coding
- provisioning.py: Skipped services (unconfigured) now reported to user instead of silently omitted

## Test Plan

- [ ] Mobile: Open Settings, scroll to "Invite Codes" → permission toggles now visible and interactive
- [ ] Onboarding: If services aren't configured, results page shows which ones were skipped and why
- [ ] Onboarding: If service provisioning fails, error message appears (not just "Failed")