### PR TITLE
Fix Google OAuth callback for Cloudflare Tunnel

### DIFF
--- a/app/src/pages/Settings.tsx
+++ b/app/src/pages/Settings.tsx
@@ -199,7 +199,10 @@ export default function Settings() {
 
   async function connectGoogle() {
     try {
-      const data = await api.get<AuthorizeResponse>('/oauth/google/authorize')
+      // Pass our origin so the backend derives the correct redirect URLs
+      // (works for LAN, localhost, and Cloudflare Tunnel access)
+      const origin = encodeURIComponent(window.location.origin)
+      const data = await api.get<AuthorizeResponse>(`/oauth/google/authorize?origin=${origin}`)
       window.location.href = data.authorizeUrl
     } catch {
       setOauthMessage({ type: 'error', text: 'Failed to start Google connection. Is OAuth configured?' })

--- a/butler/.env.example
+++ b/butler/.env.example
@@ -87,15 +87,12 @@ GROQ_API_KEY=gsk_...
 GOOGLE_CLIENT_ID=
 GOOGLE_CLIENT_SECRET=
 
-# Redirect URI must match what's configured in Google Cloud Console
-# For local dev: http://localhost:8000/api/oauth/google/callback
-# For production: https://your-tunnel-domain/api/oauth/google/callback
-GOOGLE_REDIRECT_URI=http://localhost:8000/api/oauth/google/callback
-
-# Where to redirect the browser after OAuth completes
-# For local dev: http://localhost:5173
-# For production: https://your-tunnel-domain (or wherever the PWA is served)
-OAUTH_FRONTEND_URL=http://localhost:5173
+# Redirect URI and frontend URL are auto-detected from the PWA's origin.
+# You generally don't need to set these — the correct URLs are derived
+# automatically whether you access the PWA via LAN, localhost, or Cloudflare Tunnel.
+# These only serve as fallbacks if the origin isn't provided.
+# GOOGLE_REDIRECT_URI=http://localhost:8000/api/oauth/google/callback
+# OAUTH_FRONTEND_URL=http://localhost:5173
 
 # ===================
 # Immich (optional — for photo search, read-only)

--- a/docs/google-oauth-setup.md
+++ b/docs/google-oauth-setup.md
@@ -55,11 +55,9 @@ Add the credentials to your `butler/.env` file:
 ```bash
 GOOGLE_CLIENT_ID=123456789-abcdef.apps.googleusercontent.com
 GOOGLE_CLIENT_SECRET=GOCSPX-your-secret-here
-GOOGLE_REDIRECT_URI=http://localhost:8000/api/oauth/google/callback
-OAUTH_FRONTEND_URL=http://localhost:5173
 ```
 
-For production, update `GOOGLE_REDIRECT_URI` and `OAUTH_FRONTEND_URL` to your Cloudflare Tunnel hostname.
+The redirect URI is derived automatically from how you access the PWA (LAN, localhost, or Cloudflare Tunnel), so `GOOGLE_REDIRECT_URI` and `OAUTH_FRONTEND_URL` don't need to be set. The defaults work as fallbacks if needed.
 
 ## 6. Restart Butler
 


### PR DESCRIPTION
## Summary
- Derives OAuth `redirect_uri` and `frontend_url` dynamically from the PWA's `window.location.origin` instead of hardcoded localhost env vars
- Embeds the derived URLs in the signed state JWT so the callback endpoint uses matching URLs for token exchange and browser redirect
- Env vars `GOOGLE_REDIRECT_URI` and `OAUTH_FRONTEND_URL` remain as optional fallbacks

## How it works
1. PWA passes `window.location.origin` (e.g. `https://butler.noblehaus.uk`) as a query param to `/api/oauth/google/authorize`
2. Backend constructs `redirect_uri` and `frontend_url` from the origin and embeds them in the state JWT
3. Google redirects back to the correct URL (tunnel or localhost)
4. Callback reads the URLs from the state JWT and uses them for token exchange and final redirect

## Test plan
- [ ] OAuth flow works via Cloudflare Tunnel (`https://butler.noblehaus.uk`)
- [ ] OAuth flow still works on LAN (`http://192.168.1.22:5173`)
- [ ] OAuth flow still works on localhost (`http://localhost:5173`)
- [ ] Tunnel redirect URI is registered in Google Cloud Console

Closes #189