### PR TITLE
Fix invite permissions UI + auto-provisioning improvements

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -51,6 +51,8 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            VITE_TUNNEL_DOMAIN=${{ vars.VITE_TUNNEL_DOMAIN }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
           platforms: linux/amd64,linux/arm64

--- a/README.md
+++ b/README.md
@@ -299,8 +299,22 @@ Butler uses **invite codes** for registration. The first person to log in become
 
 1. Open `http://<server-ip>:3000`
 2. Enter your admin invite code (default: `BUTLER-001`, or what you chose during setup)
-3. Complete onboarding (set your name, preferences)
+3. Complete onboarding (set your name, preferences, and optionally choose a service username/password)
 4. To add household members: **Settings → Generate Invite Code** → share the 6-character code
+
+**Invite code permissions:** When generating an invite code, toggle which Butler capabilities the new user gets:
+
+| Permission | Controls |
+|------------|----------|
+| Media | Jellyfin, Audiobookshelf, Immich tools |
+| Smart Home | Home Assistant tools |
+| Location | Location-based tools |
+| Calendar | Calendar management |
+| Email | Email tools |
+| Automation | Scheduling & automation |
+| Communication | WhatsApp tools |
+
+**Auto-provisioning:** During onboarding, if the user provides a service username and password, Butler automatically creates accounts on Jellyfin, Audiobookshelf, Nextcloud, Immich, and Home Assistant based on the invite code's permissions. Failed services can be retried from Settings. The shared password can also be changed across all services at once from Settings.
 
 ### 4.3 Set Up Media Services
 
@@ -479,6 +493,13 @@ For photos and documents, cloud backup is **optional** — see [HOMESERVER_PLAN.
 
 ## Updating
 
+**One-time prerequisite:** Log in to GHCR so Docker can pull the pre-built Butler PWA image:
+
+```bash
+# Create a GitHub PAT with read:packages scope at https://github.com/settings/tokens
+echo "<YOUR_PAT>" | docker login ghcr.io -u <YOUR_GITHUB_USERNAME> --password-stdin
+```
+
 Pull the latest code and rebuild only the stacks that changed:
 
 ```bash
@@ -490,7 +511,9 @@ bash ~/home-server/scripts/update.sh
 | `--check` | Show available updates without applying them |
 | `--force` | Rebuild all stacks, even if unchanged |
 
-The script compares local and remote commits, identifies which Docker Compose stacks were affected, pulls the changes, and rebuilds only those stacks. It's safe to run at any time — if nothing changed, it exits immediately.
+The script compares local and remote commits, identifies which Docker Compose stacks were affected, pulls the changes, and rebuilds only those stacks. The Butler PWA uses a pre-built image from GHCR (pushed by CI on each merge to main), while all other stacks rebuild locally. It's safe to run at any time — if nothing changed, it exits immediately.
+
+**CI build variable:** The GitHub Actions workflow requires a repository variable `VITE_TUNNEL_DOMAIN` set to your Cloudflare Tunnel domain (e.g. `yourdomain.com`). Set it at **Settings → Secrets and variables → Actions → Variables**.
 
 To migrate data to a different drive (e.g. from internal SSD to an external drive):
 

--- a/app/docker-compose.yml
+++ b/app/docker-compose.yml
@@ -4,6 +4,7 @@
 
 services:
   butler-app:
+    image: ghcr.io/noble1911/home-server/butler-app:latest
     build:
       context: .
       dockerfile: Dockerfile

--- a/butler/api/provisioning.py
+++ b/butler/api/provisioning.py
@@ -16,7 +16,7 @@ import aiohttp
 from tools import DatabasePool
 
 from .config import settings
-from .crypto import encrypt_password
+from .crypto import decrypt_password, encrypt_password
 
 logger = logging.getLogger(__name__)
 
@@ -126,15 +126,17 @@ async def provision_user_accounts(
             logger.error("Failed to provision %s for user %s: %s", service, user_id, e)
             await db.execute(
                 """INSERT INTO butler.service_credentials
-                   (user_id, service, username, status, error_message)
-                   VALUES ($1, $2, $3, 'failed', $4)
+                   (user_id, service, username, password_encrypted, status, error_message)
+                   VALUES ($1, $2, $3, $4, 'failed', $5)
                    ON CONFLICT (user_id, service) DO UPDATE SET
                      username = EXCLUDED.username,
+                     password_encrypted = COALESCE(EXCLUDED.password_encrypted, butler.service_credentials.password_encrypted),
                      status = 'failed',
                      error_message = EXCLUDED.error_message""",
                 user_id,
                 service,
                 username,
+                encrypt_password(password),
                 str(e),
             )
             results.append(
@@ -345,4 +347,241 @@ _PROVISIONERS: dict[str, Callable[[str, str], Awaitable[str]]] = {
     "nextcloud": _provision_nextcloud,
     "immich": _provision_immich,
     "homeassistant": _provision_homeassistant,
+}
+
+
+# ── De-provisioning (delete service accounts) ────────────────────────
+
+
+async def deprovision_user_accounts(
+    user_id: str,
+    pool: DatabasePool,
+) -> list[dict]:
+    """Delete user accounts on downstream services. Best-effort.
+
+    Reads active credentials from DB and calls per-service delete APIs.
+    Returns a list of result dicts with keys: service, status, error.
+    """
+    db = pool.pool
+    rows = await db.fetch(
+        """SELECT service, username, external_id, status
+           FROM butler.service_credentials
+           WHERE user_id = $1 AND status = 'active'""",
+        user_id,
+    )
+    results: list[dict] = []
+    for row in rows:
+        service = row["service"]
+        external_id = row["external_id"]
+        username = row["username"]
+        if not external_id and service != "nextcloud":
+            logger.warning("No external_id for %s/%s, skipping delete", user_id, service)
+            results.append({"service": service, "status": "skipped", "error": "No external ID"})
+            continue
+        deprovisioner = _DEPROVISIONERS.get(service)
+        if not deprovisioner or not _service_is_configured(service):
+            results.append({"service": service, "status": "skipped", "error": "Not configured"})
+            continue
+        try:
+            await deprovisioner(external_id or username, username)
+            await db.execute(
+                "UPDATE butler.service_credentials SET status = 'revoked' WHERE user_id = $1 AND service = $2",
+                user_id, service,
+            )
+            results.append({"service": service, "status": "revoked"})
+            logger.info("Deprovisioned %s account for user %s", service, user_id)
+        except Exception as e:
+            logger.error("Failed to deprovision %s for user %s: %s", service, user_id, e)
+            results.append({"service": service, "status": "failed", "error": str(e)})
+    return results
+
+
+async def _deprovision_jellyfin(external_id: str, _username: str) -> None:
+    async with aiohttp.ClientSession(timeout=_HTTP_TIMEOUT) as session:
+        headers = {"Authorization": f'MediaBrowser Token="{settings.jellyfin_api_key}"'}
+        async with session.delete(
+            f"{settings.jellyfin_url}/Users/{external_id}", headers=headers,
+        ) as resp:
+            if resp.status not in (200, 204, 404):
+                raise RuntimeError(f"Jellyfin delete failed: HTTP {resp.status}")
+
+
+async def _deprovision_audiobookshelf(external_id: str, _username: str) -> None:
+    async with aiohttp.ClientSession(timeout=_HTTP_TIMEOUT) as session:
+        headers = {"Authorization": f"Bearer {settings.audiobookshelf_admin_token}"}
+        async with session.delete(
+            f"{settings.audiobookshelf_url}/api/users/{external_id}", headers=headers,
+        ) as resp:
+            if resp.status not in (200, 204, 404):
+                raise RuntimeError(f"Audiobookshelf delete failed: HTTP {resp.status}")
+
+
+async def _deprovision_nextcloud(_external_id: str, username: str) -> None:
+    async with aiohttp.ClientSession(timeout=_HTTP_TIMEOUT) as session:
+        auth_str = f"{settings.nextcloud_admin_user}:{settings.nextcloud_admin_password}"
+        auth_header = base64.b64encode(auth_str.encode()).decode()
+        headers = {
+            "Authorization": f"Basic {auth_header}",
+            "OCS-APIRequest": "true",
+        }
+        async with session.delete(
+            f"{settings.nextcloud_url}/ocs/v1.php/cloud/users/{username}",
+            headers=headers, params={"format": "json"},
+        ) as resp:
+            if resp.status not in (200, 404):
+                raise RuntimeError(f"Nextcloud delete failed: HTTP {resp.status}")
+
+
+async def _deprovision_immich(external_id: str, _username: str) -> None:
+    async with aiohttp.ClientSession(timeout=_HTTP_TIMEOUT) as session:
+        headers = {"x-api-key": settings.immich_api_key}
+        async with session.delete(
+            f"{settings.immich_url}/api/admin/users/{external_id}", headers=headers,
+        ) as resp:
+            if resp.status not in (200, 204, 404):
+                raise RuntimeError(f"Immich delete failed: HTTP {resp.status}")
+
+
+async def _deprovision_homeassistant(external_id: str, _username: str) -> None:
+    ws_url = settings.home_assistant_url.replace("https://", "wss://").replace(
+        "http://", "ws://"
+    )
+    ws_url = f"{ws_url}/api/websocket"
+    ws_timeout = aiohttp.ClientTimeout(total=30)
+    async with aiohttp.ClientSession(timeout=ws_timeout) as session:
+        async with session.ws_connect(ws_url) as ws:
+            msg = await ws.receive_json()
+            if msg.get("type") != "auth_required":
+                raise RuntimeError(f"HA WebSocket unexpected: {msg.get('type')}")
+            await ws.send_json({"type": "auth", "access_token": settings.home_assistant_token})
+            msg = await ws.receive_json()
+            if msg.get("type") != "auth_ok":
+                raise RuntimeError(f"HA WebSocket auth failed: {msg}")
+            await ws.send_json({"id": 1, "type": "config/auth/delete", "user_id": external_id})
+            msg = await ws.receive_json()
+            if not msg.get("success"):
+                error = msg.get("error", {}).get("message", str(msg))
+                raise RuntimeError(f"HA user deletion failed: {error}")
+
+
+_DEPROVISIONERS: dict[str, Callable[[str, str], Awaitable[None]]] = {
+    "jellyfin": _deprovision_jellyfin,
+    "audiobookshelf": _deprovision_audiobookshelf,
+    "nextcloud": _deprovision_nextcloud,
+    "immich": _deprovision_immich,
+    "homeassistant": _deprovision_homeassistant,
+}
+
+
+# ── Password change propagation ──────────────────────────────────────
+
+
+async def update_service_passwords(
+    user_id: str,
+    new_password: str,
+    pool: DatabasePool,
+) -> list[dict]:
+    """Change password on all active service accounts for a user.
+
+    Returns a list of result dicts with keys: service, status, error.
+    """
+    db = pool.pool
+    rows = await db.fetch(
+        """SELECT service, username, external_id
+           FROM butler.service_credentials
+           WHERE user_id = $1 AND status = 'active'""",
+        user_id,
+    )
+    results: list[dict] = []
+    encrypted = encrypt_password(new_password)
+    for row in rows:
+        service = row["service"]
+        external_id = row["external_id"]
+        username = row["username"]
+        changer = _PASSWORD_CHANGERS.get(service)
+        if not changer or not _service_is_configured(service):
+            results.append({"service": service, "status": "skipped", "error": "Not configured"})
+            continue
+        if not external_id and service != "nextcloud":
+            results.append({"service": service, "status": "skipped", "error": "No external ID"})
+            continue
+        try:
+            await changer(external_id or username, username, new_password)
+            await db.execute(
+                "UPDATE butler.service_credentials SET password_encrypted = $3 WHERE user_id = $1 AND service = $2",
+                user_id, service, encrypted,
+            )
+            results.append({"service": service, "status": "updated"})
+            logger.info("Updated %s password for user %s", service, user_id)
+        except Exception as e:
+            logger.error("Failed to update %s password for user %s: %s", service, user_id, e)
+            results.append({"service": service, "status": "failed", "error": str(e)})
+
+    # Also update the stored master password on the user record
+    if any(r["status"] == "updated" for r in results):
+        await db.execute(
+            "UPDATE butler.users SET service_password_encrypted = $2 WHERE id = $1",
+            user_id, encrypted,
+        )
+
+    return results
+
+
+async def _change_password_jellyfin(external_id: str, _username: str, new_password: str) -> None:
+    async with aiohttp.ClientSession(timeout=_HTTP_TIMEOUT) as session:
+        headers = {"Authorization": f'MediaBrowser Token="{settings.jellyfin_api_key}"'}
+        async with session.post(
+            f"{settings.jellyfin_url}/Users/{external_id}/Password",
+            json={"NewPw": new_password}, headers=headers,
+        ) as resp:
+            if resp.status not in (200, 204):
+                raise RuntimeError(f"Jellyfin password change failed: HTTP {resp.status}")
+
+
+async def _change_password_audiobookshelf(external_id: str, _username: str, new_password: str) -> None:
+    async with aiohttp.ClientSession(timeout=_HTTP_TIMEOUT) as session:
+        headers = {"Authorization": f"Bearer {settings.audiobookshelf_admin_token}"}
+        async with session.patch(
+            f"{settings.audiobookshelf_url}/api/users/{external_id}",
+            json={"password": new_password}, headers=headers,
+        ) as resp:
+            if resp.status not in (200, 204):
+                raise RuntimeError(f"Audiobookshelf password change failed: HTTP {resp.status}")
+
+
+async def _change_password_nextcloud(_external_id: str, username: str, new_password: str) -> None:
+    async with aiohttp.ClientSession(timeout=_HTTP_TIMEOUT) as session:
+        auth_str = f"{settings.nextcloud_admin_user}:{settings.nextcloud_admin_password}"
+        auth_header = base64.b64encode(auth_str.encode()).decode()
+        headers = {
+            "Authorization": f"Basic {auth_header}",
+            "OCS-APIRequest": "true",
+            "Content-Type": "application/x-www-form-urlencoded",
+        }
+        async with session.put(
+            f"{settings.nextcloud_url}/ocs/v1.php/cloud/users/{username}",
+            data={"key": "password", "value": new_password},
+            headers=headers, params={"format": "json"},
+        ) as resp:
+            if resp.status != 200:
+                raise RuntimeError(f"Nextcloud password change failed: HTTP {resp.status}")
+
+
+async def _change_password_immich(external_id: str, _username: str, new_password: str) -> None:
+    async with aiohttp.ClientSession(timeout=_HTTP_TIMEOUT) as session:
+        headers = {"x-api-key": settings.immich_api_key}
+        async with session.put(
+            f"{settings.immich_url}/api/admin/users/{external_id}",
+            json={"password": new_password}, headers=headers,
+        ) as resp:
+            if resp.status not in (200, 204):
+                raise RuntimeError(f"Immich password change failed: HTTP {resp.status}")
+
+
+_PASSWORD_CHANGERS: dict[str, Callable[[str, str, str], Awaitable[None]]] = {
+    "jellyfin": _change_password_jellyfin,
+    "audiobookshelf": _change_password_audiobookshelf,
+    "nextcloud": _change_password_nextcloud,
+    "immich": _change_password_immich,
+    # Home Assistant: no admin API to change another user's password
 }

--- a/butler/migrations/012_user_service_credentials.sql
+++ b/butler/migrations/012_user_service_credentials.sql
@@ -1,0 +1,7 @@
+-- Store service credentials on user record for re-provisioning.
+-- These are the shared username + password chosen during onboarding,
+-- encrypted with Fernet (same as service_credentials.password_encrypted).
+
+ALTER TABLE butler.users
+    ADD COLUMN IF NOT EXISTS service_username TEXT,
+    ADD COLUMN IF NOT EXISTS service_password_encrypted TEXT;

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -134,9 +134,17 @@ fi
 if [[ ${#REBUILD_STACKS[@]} -gt 0 ]]; then
     echo ""
     for compose_file in "${REBUILD_STACKS[@]}"; do
-        echo -e "${BLUE}==>${NC} Rebuilding $(dirname "$compose_file")..."
-        docker compose -f "$compose_file" up -d --build --remove-orphans
-        echo -e "  ${GREEN}✓${NC} $(dirname "$compose_file") updated"
+        stack_name=$(dirname "$compose_file")
+        echo -e "${BLUE}==>${NC} Updating ${stack_name}..."
+        if [[ "$compose_file" == "app/docker-compose.yml" ]]; then
+            # Butler PWA: pull pre-built image from GHCR (built by CI)
+            docker compose -f "$compose_file" pull
+            docker compose -f "$compose_file" up -d --remove-orphans
+        else
+            # All other stacks: rebuild locally
+            docker compose -f "$compose_file" up -d --build --remove-orphans
+        fi
+        echo -e "  ${GREEN}✓${NC} ${stack_name} updated"
     done
 fi
 


### PR DESCRIPTION
## Summary

Fixes the missing invite permission toggles by resolving the deployment gap: code was merged but never reached production because CI didn't pass the `VITE_TUNNEL_DOMAIN` build arg to Docker, and production docker-compose didn't use the GHCR image. This PR also adds complete credential re-provisioning, de-provisioning, and password propagation workflows.

## Changes

1. **CI build args** — Pass `VITE_TUNNEL_DOMAIN` to Docker build in GitHub Actions so GHCR images have correct Cloudflare Tunnel URLs
2. **GHCR deployment** — Add `image:` to `app/docker-compose.yml` and update `scripts/update.sh` to pull pre-built images instead of rebuilding app locally
3. **"Used by" fix** — LEFT JOIN users table in admin API to show actual display names instead of invite code IDs
4. **Re-provisioning** — Store encrypted service credentials during onboarding; `POST /api/user/reprovision` retries failed services; frontend retry button
5. **De-provisioning** — Delete downstream service accounts (Jellyfin, Audiobookshelf, Nextcloud, Immich, Home Assistant) when user is removed; new `DELETE /api/admin/users/{id}` endpoint
6. **Password changes** — `PUT /api/user/service-password` propagates password to all active services; frontend form in Settings
7. **README** — Document GHCR login prerequisite, `VITE_TUNNEL_DOMAIN` CI variable, permission toggles, and auto-provisioning workflow

Closes #180 #185