### PR TITLE
Wire up missing tools and add tutorial tab

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -8,6 +8,7 @@ import Services from './pages/Services'
 import Downloads from './pages/Downloads'
 import Dashboard from './pages/Dashboard'
 import Settings from './pages/Settings'
+import Tutorial from './pages/Tutorial'
 import Login from './pages/Login'
 import Onboarding from './pages/Onboarding'
 
@@ -57,6 +58,7 @@ function AppContent() {
         <Route path="/services" element={<Services />} />
         <Route path="/downloads" element={<Downloads />} />
         <Route path="/dashboard" element={<Dashboard />} />
+        <Route path="/tutorial" element={<Tutorial />} />
         <Route path="/settings" element={<Settings />} />
       </Route>
 

--- a/app/src/components/layout/BottomNav.tsx
+++ b/app/src/components/layout/BottomNav.tsx
@@ -5,6 +5,7 @@ const navItems = [
   { path: '/services', label: 'Services', icon: GridIcon },
   { path: '/downloads', label: 'Downloads', icon: DownloadIcon },
   { path: '/dashboard', label: 'Dashboard', icon: ChartIcon },
+  { path: '/tutorial', label: 'Guide', icon: BookIcon },
   { path: '/settings', label: 'Settings', icon: CogIcon },
 ]
 
@@ -17,14 +18,14 @@ export default function BottomNav() {
             key={item.path}
             to={item.path}
             className={({ isActive }) =>
-              `flex flex-col items-center gap-1 px-4 py-2 rounded-lg transition-colors ${
+              `flex flex-col items-center gap-1 px-3 py-2 rounded-lg transition-colors ${
                 isActive
                   ? 'text-accent'
                   : 'text-butler-400 hover:text-butler-200'
               }`
             }
           >
-            <item.icon className="w-6 h-6" />
+            <item.icon className="w-5 h-5" />
             <span className="text-xs">{item.label}</span>
           </NavLink>
         ))}
@@ -62,6 +63,14 @@ function DownloadIcon({ className }: { className?: string }) {
   return (
     <svg className={className} fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
       <path strokeLinecap="round" strokeLinejoin="round" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
+    </svg>
+  )
+}
+
+function BookIcon({ className }: { className?: string }) {
+  return (
+    <svg className={className} fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+      <path strokeLinecap="round" strokeLinejoin="round" d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253" />
     </svg>
   )
 }

--- a/app/src/components/layout/Sidebar.tsx
+++ b/app/src/components/layout/Sidebar.tsx
@@ -5,6 +5,7 @@ const navItems = [
   { path: '/services', label: 'Services', icon: GridIcon },
   { path: '/downloads', label: 'Downloads', icon: DownloadIcon },
   { path: '/dashboard', label: 'Dashboard', icon: ChartIcon },
+  { path: '/tutorial', label: 'Guide', icon: BookIcon },
   { path: '/settings', label: 'Settings', icon: CogIcon },
 ]
 
@@ -62,6 +63,14 @@ function DownloadIcon({ className }: { className?: string }) {
   return (
     <svg className={className} fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
       <path strokeLinecap="round" strokeLinejoin="round" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
+    </svg>
+  )
+}
+
+function BookIcon({ className }: { className?: string }) {
+  return (
+    <svg className={className} fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+      <path strokeLinecap="round" strokeLinejoin="round" d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253" />
     </svg>
   )
 }

--- a/app/src/components/tutorial/CategorySection.tsx
+++ b/app/src/components/tutorial/CategorySection.tsx
@@ -1,0 +1,75 @@
+import { useState } from 'react'
+import ExamplePrompt from './ExamplePrompt'
+
+export interface TutorialTool {
+  name: string
+  description: string
+  examples: string[]
+}
+
+export interface CategoryData {
+  id: string
+  title: string
+  description: string
+  icon: string
+  permission?: string
+  tools: TutorialTool[]
+}
+
+interface CategorySectionProps {
+  category: CategoryData
+  defaultOpen?: boolean
+}
+
+export default function CategorySection({ category, defaultOpen = false }: CategorySectionProps) {
+  const [expanded, setExpanded] = useState(defaultOpen)
+
+  return (
+    <div className="card overflow-hidden">
+      <button
+        onClick={() => setExpanded(!expanded)}
+        className="w-full flex items-center gap-3 p-4 text-left hover:bg-butler-800/50 transition-colors"
+      >
+        <span className="text-2xl shrink-0">{category.icon}</span>
+        <div className="flex-1 min-w-0">
+          <h3 className="text-sm font-semibold text-butler-200">{category.title}</h3>
+          <p className="text-xs text-butler-400 truncate">{category.description}</p>
+        </div>
+        <div className="flex items-center gap-2 shrink-0">
+          {category.permission && (
+            <span className="hidden sm:inline-flex items-center gap-1 px-2 py-0.5 bg-butler-700/50 rounded text-[10px] text-butler-400">
+              <svg className="w-2.5 h-2.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                <path strokeLinecap="round" strokeLinejoin="round" d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z" />
+              </svg>
+              {category.permission}
+            </span>
+          )}
+          <svg
+            className={`w-5 h-5 text-butler-500 transition-transform duration-200 ${expanded ? 'rotate-180' : ''}`}
+            fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}
+          >
+            <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
+          </svg>
+        </div>
+      </button>
+
+      {expanded && (
+        <div className="px-4 pb-4 space-y-4 border-t border-butler-700/50">
+          {category.tools.map((tool) => (
+            <div key={tool.name} className="pt-3 space-y-2">
+              <div>
+                <h4 className="text-sm font-medium text-butler-300">{tool.name}</h4>
+                <p className="text-xs text-butler-400">{tool.description}</p>
+              </div>
+              <div className="space-y-1.5">
+                {tool.examples.map((example) => (
+                  <ExamplePrompt key={example} prompt={example} />
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/app/src/components/tutorial/ExamplePrompt.tsx
+++ b/app/src/components/tutorial/ExamplePrompt.tsx
@@ -1,0 +1,45 @@
+import { useState } from 'react'
+
+interface ExamplePromptProps {
+  prompt: string
+}
+
+export default function ExamplePrompt({ prompt }: ExamplePromptProps) {
+  const [copied, setCopied] = useState(false)
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(prompt)
+      setCopied(true)
+      setTimeout(() => setCopied(false), 2000)
+    } catch {
+      // Fallback for older browsers
+      const textarea = document.createElement('textarea')
+      textarea.value = prompt
+      document.body.appendChild(textarea)
+      textarea.select()
+      document.execCommand('copy')
+      document.body.removeChild(textarea)
+      setCopied(true)
+      setTimeout(() => setCopied(false), 2000)
+    }
+  }
+
+  return (
+    <button
+      onClick={handleCopy}
+      className="flex items-center gap-2 w-full px-3 py-2 bg-butler-800/60 hover:bg-butler-700 rounded-lg text-sm text-butler-300 hover:text-butler-200 transition-colors text-left group"
+    >
+      <span className="flex-1 truncate">&ldquo;{prompt}&rdquo;</span>
+      {copied ? (
+        <svg className="w-4 h-4 text-green-400 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+          <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
+        </svg>
+      ) : (
+        <svg className="w-4 h-4 text-butler-500 group-hover:text-butler-400 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+          <path strokeLinecap="round" strokeLinejoin="round" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
+        </svg>
+      )}
+    </button>
+  )
+}

--- a/app/src/pages/Tutorial.tsx
+++ b/app/src/pages/Tutorial.tsx
@@ -1,0 +1,322 @@
+import { useNavigate } from 'react-router-dom'
+import CategorySection, { type CategoryData } from '../components/tutorial/CategorySection'
+import ExamplePrompt from '../components/tutorial/ExamplePrompt'
+
+const CATEGORIES: CategoryData[] = [
+  {
+    id: 'memory',
+    title: 'Memory & Personalization',
+    description: 'Butler learns your preferences and adapts to you',
+    icon: '\u{1F9E0}',
+    tools: [
+      {
+        name: 'Remember Things',
+        description: 'Store facts about your preferences, habits, and interests',
+        examples: [
+          'Remember that I prefer thriller movies',
+          'I like my coffee black with no sugar',
+          'My favourite football team is Arsenal',
+        ],
+      },
+      {
+        name: 'Recall Information',
+        description: 'Ask Butler what it knows about you',
+        examples: [
+          'What do you know about my preferences?',
+          'What are my favourite movies?',
+        ],
+      },
+      {
+        name: 'Adjust Personality',
+        description: 'Change how Butler communicates with you',
+        examples: [
+          'Be more casual in your responses',
+          'Use more humour',
+          'Keep your answers short and concise',
+        ],
+      },
+    ],
+  },
+  {
+    id: 'weather',
+    title: 'Weather',
+    description: 'Current conditions and forecasts',
+    icon: '\u{26C5}',
+    tools: [
+      {
+        name: 'Weather Updates',
+        description: 'Get current weather and multi-day forecasts for any location',
+        examples: [
+          "What's the weather like today?",
+          'Will it rain tomorrow?',
+          'Give me the 5-day forecast',
+        ],
+      },
+    ],
+  },
+  {
+    id: 'media',
+    title: 'Movies, TV & Books',
+    description: 'Search, request, and manage your media library',
+    icon: '\u{1F3AC}',
+    permission: 'media',
+    tools: [
+      {
+        name: 'Movies',
+        description: 'Search for movies and add them to your library',
+        examples: [
+          'Find the movie Inception',
+          'Add The Batman to my library',
+          'Is Oppenheimer in my collection?',
+        ],
+      },
+      {
+        name: 'TV Shows',
+        description: 'Search for TV series and track episodes',
+        examples: [
+          'Add Breaking Bad to my shows',
+          'Is The Last of Us downloading?',
+          "What's the download progress?",
+        ],
+      },
+      {
+        name: 'Books & Audiobooks',
+        description: 'Find and download books via Open Library',
+        examples: [
+          'Search for audiobooks by Stephen King',
+          'Find the book Project Hail Mary',
+          'Download Dune by Frank Herbert',
+        ],
+      },
+      {
+        name: 'Photos',
+        description: 'Search your Immich photo library using natural language',
+        examples: [
+          'Show me photos from last Christmas',
+          'Find pictures of the beach',
+          'Search for photos of the dog',
+        ],
+      },
+      {
+        name: 'Playback',
+        description: 'Control what\'s playing on Jellyfin across your devices',
+        examples: [
+          "What's currently playing?",
+          'Pause the TV',
+          'Show me recently added movies',
+        ],
+      },
+      {
+        name: 'File Management',
+        description: 'Browse, move, copy, rename, and organise media files on the server',
+        examples: [
+          'List the files in Downloads',
+          'Move that file to Media/Movies',
+          'Create a folder for Season 2',
+          'Find any low quality videos in my library',
+        ],
+      },
+    ],
+  },
+  {
+    id: 'home',
+    title: 'Smart Home',
+    description: 'Control lights, switches, and devices via Home Assistant',
+    icon: '\u{1F3E0}',
+    permission: 'home',
+    tools: [
+      {
+        name: 'Device Control',
+        description: 'Turn devices on/off, check states, and run automations',
+        examples: [
+          'Turn off the living room lights',
+          'Set the bedroom temperature to 21',
+          'Is the front door locked?',
+          'What smart devices do I have?',
+        ],
+      },
+    ],
+  },
+  {
+    id: 'location',
+    title: 'Location',
+    description: 'Track household members via phone location',
+    icon: '\u{1F4CD}',
+    permission: 'location',
+    tools: [
+      {
+        name: 'Phone Location',
+        description: 'Check where household members are and if they\'re home',
+        examples: [
+          'Is everyone home?',
+          'How far is Dad from home?',
+          "Where's Mum?",
+        ],
+      },
+    ],
+  },
+  {
+    id: 'calendar',
+    title: 'Calendar',
+    description: 'View your Google Calendar events and schedule',
+    icon: '\u{1F4C5}',
+    permission: 'calendar',
+    tools: [
+      {
+        name: 'Events',
+        description: 'Check upcoming events and search your calendar',
+        examples: [
+          "What's on my calendar today?",
+          'Any meetings tomorrow morning?',
+          "What's my schedule this week?",
+        ],
+      },
+    ],
+  },
+  {
+    id: 'email',
+    title: 'Email',
+    description: 'Search and read your Gmail messages',
+    icon: '\u{2709}\u{FE0F}',
+    permission: 'email',
+    tools: [
+      {
+        name: 'Gmail',
+        description: 'Read recent emails, search by sender, subject, or content',
+        examples: [
+          'Check my recent emails',
+          'Search for emails from Sarah',
+          'Any emails about the project?',
+        ],
+      },
+    ],
+  },
+  {
+    id: 'automation',
+    title: 'Reminders & Automation',
+    description: 'Schedule recurring tasks and one-time reminders',
+    icon: '\u{23F0}',
+    permission: 'automation',
+    tools: [
+      {
+        name: 'Scheduled Tasks',
+        description: 'Create reminders, recurring checks, and automated routines',
+        examples: [
+          'Remind me to water plants every Monday',
+          'Send me a weather update every morning',
+          'What reminders do I have?',
+        ],
+      },
+    ],
+  },
+  {
+    id: 'communication',
+    title: 'WhatsApp',
+    description: 'Send messages via WhatsApp',
+    icon: '\u{1F4AC}',
+    permission: 'communication',
+    tools: [
+      {
+        name: 'Messages',
+        description: 'Send WhatsApp notifications to yourself or household members',
+        examples: [
+          "Send a WhatsApp to Mum saying I'm on my way",
+          'Message the family group about dinner',
+        ],
+      },
+    ],
+  },
+  {
+    id: 'system',
+    title: 'Server & System',
+    description: 'Monitor server health, storage, and updates',
+    icon: '\u{1F5A5}\u{FE0F}',
+    tools: [
+      {
+        name: 'Health Checks',
+        description: 'Check if all services are running and view active alerts',
+        examples: [
+          "How's the server doing?",
+          'Are all services running?',
+          'Any health alerts?',
+        ],
+      },
+      {
+        name: 'Storage',
+        description: 'Monitor disk usage on the external drive and internal SSD',
+        examples: [
+          'Check storage usage',
+          'How much space is left?',
+          "What's using the most storage?",
+        ],
+      },
+    ],
+  },
+]
+
+const QUICK_START_PROMPTS = [
+  "What's the weather like today?",
+  "What's on my calendar?",
+  'Find me a good movie to watch',
+  "How's the server doing?",
+]
+
+export default function Tutorial() {
+  const navigate = useNavigate()
+
+  return (
+    <div className="p-4 space-y-6 pb-24 md:pb-6">
+      {/* Header */}
+      <div>
+        <h1 className="text-xl font-bold text-butler-100">What Butler Can Do</h1>
+        <p className="text-sm text-butler-400 mt-1">
+          Your AI assistant for media, smart home, and more. Try asking any of these.
+        </p>
+      </div>
+
+      {/* Quick Start */}
+      <div className="space-y-3">
+        <h2 className="text-sm font-medium text-butler-400 uppercase tracking-wide">Quick Start</h2>
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+          {QUICK_START_PROMPTS.map((prompt) => (
+            <ExamplePrompt key={prompt} prompt={prompt} />
+          ))}
+        </div>
+      </div>
+
+      {/* Categories */}
+      <div className="space-y-3">
+        <h2 className="text-sm font-medium text-butler-400 uppercase tracking-wide">All Features</h2>
+        <div className="space-y-2">
+          {CATEGORIES.map((category, i) => (
+            <CategorySection
+              key={category.id}
+              category={category}
+              defaultOpen={i === 0}
+            />
+          ))}
+        </div>
+      </div>
+
+      {/* Settings CTA */}
+      <div className="card p-4 border-accent/20 bg-accent/5">
+        <div className="flex items-start gap-3">
+          <svg className="w-5 h-5 text-accent shrink-0 mt-0.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+            <path strokeLinecap="round" strokeLinejoin="round" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+          </svg>
+          <div className="flex-1">
+            <p className="text-sm text-butler-200">
+              Some features need permissions to be enabled. You can manage these in Settings.
+            </p>
+            <button
+              onClick={() => navigate('/settings')}
+              className="mt-2 text-sm font-medium text-accent hover:text-accent-light transition-colors"
+            >
+              Go to Settings &rarr;
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/butler/api/deps.py
+++ b/butler/api/deps.py
@@ -16,7 +16,9 @@ from tools import (
     AlertStateManager,
     BookTool,
     DatabasePool,
+    DisplayInChatTool,
     EmbeddingService,
+    GetConversationsTool,
     GmailTool,
     GoogleCalendarTool,
     HomeAssistantTool,
@@ -35,6 +37,7 @@ from tools import (
     SonarrTool,
     StorageMonitorTool,
     Tool,
+    UpdateSoulTool,
     WeatherTool,
     SelfUpdateTool,
     WhatsAppTool,
@@ -58,6 +61,7 @@ from .ratelimit import start_ratelimit_cleanup, stop_ratelimit_cleanup
 
 ALWAYS_ALLOWED_TOOLS: set[str] = {
     "remember_fact", "recall_facts", "get_user",
+    "get_conversations", "update_soul", "display_in_chat",
     "weather", "server_health", "storage_monitor",
 }
 
@@ -121,6 +125,9 @@ async def init_resources() -> None:
         "remember_fact": RememberFactTool(_db_pool, _embedding_service),
         "recall_facts": RecallFactsTool(_db_pool, _embedding_service),
         "get_user": GetUserTool(_db_pool),
+        "get_conversations": GetConversationsTool(_db_pool),
+        "update_soul": UpdateSoulTool(_db_pool),
+        "display_in_chat": DisplayInChatTool(),
     }
 
     # Only register HA tools if configured


### PR DESCRIPTION
## Summary

Registers three previously unimplemented AI tools and adds a comprehensive tutorial/guide tab to the PWA to help users discover Butler's capabilities.

**Backend:** DisplayInChatTool, GetConversationsTool, UpdateSoulTool are now available to Claude. MediaFilesTool gains move/copy/mkdir actions for complete file management.

**Frontend:** New 6-tab navigation with Guide tab featuring 10 categories, 40+ example prompts, and permission badges showing which features need enabling.

## Changes

- `butler/api/deps.py`: Register 3 missing tools in ALWAYS_ALLOWED_TOOLS
- `butler/tools/media_files.py`: Add move, copy, mkdir actions with full path safety
- `app/src/pages/Tutorial.tsx`: Main guide page with memory, weather, media, smart home, location, calendar, email, automation, communication, and system categories
- `app/src/components/tutorial/`: ExamplePrompt (copyable chips) and CategorySection (expandable accordions)
- Navigation updates: BottomNav, Sidebar, App router for 6 tabs

## Testing

- `npm run build` passes with no TypeScript errors
- Reduced padding on mobile nav (px-4 → px-3, w-6 → w-5) to fit 6 tabs
- Example prompts use Clipboard API with fallback for older browsers