### PR TITLE
Fix Google OAuth redirect_uri_mismatch

### DIFF
--- a/app/src/pages/Settings.tsx
+++ b/app/src/pages/Settings.tsx
@@ -244,9 +244,20 @@ export default function Settings() {
   }
 
   async function connectGoogle() {
+    // Google only allows HTTPS redirect URIs (or http://localhost).
+    // LAN IPs like http://192.168.1.22 will be rejected with redirect_uri_mismatch.
+    const loc = window.location
+    if (loc.protocol === 'http:' && loc.hostname !== 'localhost' && loc.hostname !== '127.0.0.1') {
+      setOauthMessage({
+        type: 'error',
+        text: 'Google OAuth requires HTTPS. Open Butler via your Cloudflare Tunnel URL or localhost instead.',
+      })
+      return
+    }
+
     try {
       // Pass our origin so the backend derives the correct redirect URLs
-      // (works for LAN, localhost, and Cloudflare Tunnel access)
+      // (works for localhost and Cloudflare Tunnel access)
       const origin = encodeURIComponent(window.location.origin)
       const data = await api.get<AuthorizeResponse>(`/oauth/google/authorize?origin=${origin}`)
       window.location.href = data.authorizeUrl

--- a/butler/.env.example
+++ b/butler/.env.example
@@ -91,8 +91,8 @@ GOOGLE_CLIENT_SECRET=
 # You generally don't need to set these — the correct URLs are derived
 # automatically whether you access the PWA via LAN, localhost, or Cloudflare Tunnel.
 # These only serve as fallbacks if the origin isn't provided.
-# GOOGLE_REDIRECT_URI=http://localhost:8000/api/oauth/google/callback
-# OAUTH_FRONTEND_URL=http://localhost:5173
+# GOOGLE_REDIRECT_URI=http://localhost:3000/api/oauth/google/callback
+# OAUTH_FRONTEND_URL=http://localhost:3000
 
 # ===================
 # Immich (optional — for photo search, read-only)

--- a/butler/api/config.py
+++ b/butler/api/config.py
@@ -119,8 +119,8 @@ class Settings(BaseSettings):
     # Google OAuth (for Calendar, Gmail, etc.)
     google_client_id: str = ""
     google_client_secret: str = ""
-    google_redirect_uri: str = "http://localhost:8000/api/oauth/google/callback"
-    oauth_frontend_url: str = "http://localhost:5173"
+    google_redirect_uri: str = "http://localhost:3000/api/oauth/google/callback"
+    oauth_frontend_url: str = "http://localhost:3000"
 
     # WhatsApp Gateway (outbound notifications)
     whatsapp_gateway_url: str = ""

--- a/butler/api/routes/oauth.py
+++ b/butler/api/routes/oauth.py
@@ -64,6 +64,9 @@ async def google_authorize(
         redirect_uri = f"{origin}/api/oauth/google/callback"
         frontend_url = origin
 
+    effective_uri = redirect_uri or settings.google_redirect_uri
+    logger.info("OAuth authorize: redirect_uri=%s (origin=%s)", effective_uri, origin)
+
     state = create_oauth_state(user_id, redirect_uri=redirect_uri, frontend_url=frontend_url)
     authorize_url = build_google_authorize_url(state, redirect_uri=redirect_uri)
     return OAuthAuthorizeResponse(authorizeUrl=authorize_url)

--- a/butler/docker-compose.yml
+++ b/butler/docker-compose.yml
@@ -46,8 +46,8 @@ services:
       # Google OAuth (for Calendar, Gmail, etc.)
       - GOOGLE_CLIENT_ID=${GOOGLE_CLIENT_ID:-}
       - GOOGLE_CLIENT_SECRET=${GOOGLE_CLIENT_SECRET:-}
-      - GOOGLE_REDIRECT_URI=${GOOGLE_REDIRECT_URI:-http://localhost:8000/api/oauth/google/callback}
-      - OAUTH_FRONTEND_URL=${OAUTH_FRONTEND_URL:-http://localhost:5173}
+      - GOOGLE_REDIRECT_URI=${GOOGLE_REDIRECT_URI:-http://localhost:3000/api/oauth/google/callback}
+      - OAUTH_FRONTEND_URL=${OAUTH_FRONTEND_URL:-http://localhost:3000}
       # qBittorrent (download management)
       - QBITTORRENT_URL=${QBITTORRENT_URL:-http://qbittorrent:8081}
       - QBITTORRENT_USERNAME=${QBITTORRENT_USERNAME:-admin}

--- a/docs/google-oauth-setup.md
+++ b/docs/google-oauth-setup.md
@@ -43,8 +43,13 @@ This guide walks you through creating Google OAuth credentials so Butler can acc
 3. Choose **Web application** as the application type
 4. Name it `Butler Web`
 5. Under **Authorized redirect URIs**, add:
-   - `http://localhost:8000/api/oauth/google/callback` (for local development)
-   - `https://YOUR-TUNNEL-DOMAIN/api/oauth/google/callback` (for production)
+   - `http://localhost:3000/api/oauth/google/callback` (for local access)
+   - `https://YOUR-TUNNEL-DOMAIN/api/oauth/google/callback` (for Cloudflare Tunnel access)
+   > **Note:** The redirect URI uses port 3000 (the PWA/nginx port), not 8000 (the API port).
+   > Nginx proxies `/api/*` to the Butler API automatically.
+   > Google only allows HTTP redirect URIs for `localhost` — LAN IP access
+   > (e.g. `http://192.168.1.22:3000`) won't work for OAuth. Use the Cloudflare
+   > Tunnel URL or localhost instead.
 6. Click **Create**
 7. Copy the **Client ID** and **Client Secret**
 


### PR DESCRIPTION
## Summary

Fixed `redirect_uri_mismatch` errors when connecting Google accounts. The OAuth flow dynamically derives the redirect URI from the PWA's origin, but defaults and documentation referenced the wrong ports (8000/5173 instead of 3000).

## Changes

- Updated default ports from 8000 → 3000 in config and docker-compose
- Fixed documentation to clarify the correct redirect URI format
- Added HTTPS-only validation on the PWA (Google blocks HTTP on non-localhost IPs)
- Added debug logging to show exact redirect_uri being sent to Google

## Test Plan

- [ ] Verify `http://localhost:3000/api/oauth/google/callback` is registered in Google Cloud Console
- [ ] Connect Google account from localhost — should work
- [ ] Connect from Cloudflare Tunnel URL — should work
- [ ] Attempt from LAN IP — should show helpful error message
- [ ] Check logs for `OAuth authorize: redirect_uri=...` to debug future mismatches