### PR TITLE
Improve Claude Code: skip permissions + conversation context

### DIFF
--- a/docker/claude-code-shim/app.py
+++ b/docker/claude-code-shim/app.py
@@ -60,7 +60,7 @@ async def run_claude(request: web.Request) -> web.StreamResponse:
     logger.info("Running claude --print for %d-char message", len(message))
 
     proc = await asyncio.create_subprocess_exec(
-        CLAUDE_BIN, "--print", message,
+        CLAUDE_BIN, "--print", "--dangerously-skip-permissions", message,
         cwd=str(WORK_DIR),
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.STDOUT,


### PR DESCRIPTION
## Summary
- **Skip permissions**: Add `--dangerously-skip-permissions` flag to the Claude Code shim so it can execute file edits, bash commands, etc. on the server without interactive approval (there's no TTY to approve on a headless server)
- **Conversation context**: Fetch the last 10 `claude_code` messages from conversation history and inject them into the prompt, giving Claude Code continuity across messages instead of starting a fresh conversation every time

## Changes
- `docker/claude-code-shim/app.py` — Added `--dangerously-skip-permissions` to subprocess args
- `butler/api/routes/chat.py` — Added history fetch + contextualised message building before calling the shim

## Test plan
- [ ] Send a Claude Code message via the Butler PWA — verify it responds and can take actions (file reads, edits)
- [ ] Send a follow-up message referencing the first — verify Claude Code understands the context
- [ ] Verify normal Butler chat is unaffected