### PR TITLE
fix(jellyfin): retire Docker container, point Butler at native macOS app

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,7 +101,7 @@ The Mac Mini is set up and all Docker stacks are deployed via OrbStack. Active w
 ### Deployed Stacks
 | Stack | Services | Status |
 |-------|----------|--------|
-| **media-stack** | Jellyfin, Radarr, Sonarr, Bazarr, Seerr | Running |
+| **media-stack** | Radarr, Sonarr, Bazarr, Seerr | Running |
 | **download-stack** | qBittorrent, Prowlarr | Running |
 | **books-stack** | Audiobookshelf, LazyLibrarian | Running |
 | **photos-files-stack** | Immich, PostgreSQL, Redis, Nextcloud | Running |
@@ -112,6 +112,7 @@ The Mac Mini is set up and all Docker stacks are deployed via OrbStack. Active w
 ### Native Services (not Docker)
 | Service | Description | Status |
 |---------|-------------|--------|
+| **Jellyfin** | Media streaming — native `/Applications/Jellyfin.app` (uses VideoToolbox HW transcode; Docker container retired 2026-05-25). Port 8096; Butler reaches it via `host.docker.internal:8096`. | Running |
 | **wire-pod** | Vector robot server (WirePod v1.2.13 macOS app) | Running |
 
 ### Butler API (~4k LOC, FastAPI)
@@ -141,7 +142,7 @@ home-server/
 ├── docker/                # Docker Compose stacks
 │   ├── books-stack/       # Audiobookshelf, LazyLibrarian
 │   ├── download-stack/    # qBittorrent, Prowlarr
-│   ├── media-stack/       # Jellyfin, Radarr, Sonarr, Bazarr, Seerr
+│   ├── media-stack/       # Radarr, Sonarr, Bazarr, Seerr (Jellyfin = native app, see above)
 │   ├── messaging-stack/   # WhatsApp gateway
 │   ├── photos-files-stack/# Immich, Nextcloud, PostgreSQL
 │   ├── smart-home-stack/  # Home Assistant, Cloudflare Tunnel

--- a/HOMESERVER_PLAN.md
+++ b/HOMESERVER_PLAN.md
@@ -139,7 +139,7 @@
 
 | Service | Homepage | Purpose | Run Method | RAM (Idle) | RAM (Peak) | Port |
 |---------|----------|---------|------------|------------|------------|------|
-| [**Jellyfin**](https://jellyfin.org/) | [jellyfin.org](https://jellyfin.org/) | Media streaming (4K HDR, Dolby Atmos) | Docker container | 500MB | 4GB* | 8096 |
+| [**Jellyfin**](https://jellyfin.org/) | [jellyfin.org](https://jellyfin.org/) | Media streaming (4K HDR, Dolby Atmos) | Native macOS app | 500MB | 4GB* | 8096 |
 | [**Radarr**](https://radarr.video/) | [radarr.video](https://radarr.video/) | Movie automation & management | Docker container | 300MB | 500MB | 7878 |
 | [**Sonarr**](https://sonarr.tv/) | [sonarr.tv](https://sonarr.tv/) | TV series automation & management | Docker container | 300MB | 500MB | 8989 |
 | [**Bazarr**](https://www.bazarr.media/) | [bazarr.media](https://www.bazarr.media/) | Subtitle automation | Docker container | 200MB | 400MB | 6767 |

--- a/butler/docker-compose.yml
+++ b/butler/docker-compose.yml
@@ -36,8 +36,8 @@ services:
       # Sonarr
       - SONARR_URL=http://sonarr:8989
       - SONARR_API_KEY=${SONARR_API_KEY:-}
-      # Jellyfin
-      - JELLYFIN_URL=http://jellyfin:8096
+      # Jellyfin — native macOS app on the host (not a container); reach via host.docker.internal
+      - JELLYFIN_URL=http://host.docker.internal:8096
       - JELLYFIN_API_KEY=${JELLYFIN_API_KEY:-}
       # Health & storage monitoring
       - EXTERNAL_DRIVE_PATH=${EXTERNAL_DRIVE_PATH:-/mnt/external}

--- a/butler/tools/server_health.py
+++ b/butler/tools/server_health.py
@@ -41,7 +41,10 @@ DEFAULT_TIMEOUT = 5
 DEFAULT_SERVICES: dict[str, dict[str, Any]] = {
     # Media stack
     "jellyfin": {
-        "url": "http://jellyfin:8096/health",
+        # Native macOS Jellyfin.app on the host (not a container — the Linux image
+        # can't use Apple VideoToolbox for HW transcode). Reachable from this
+        # container via host.docker.internal.
+        "url": "http://host.docker.internal:8096/health",
         "stack": "media",
     },
     "radarr": {

--- a/docker/media-stack/docker-compose.yml
+++ b/docker/media-stack/docker-compose.yml
@@ -1,30 +1,8 @@
 services:
-  jellyfin:
-    image: jellyfin/jellyfin:10.11.6
-    container_name: jellyfin
-    environment:
-      - PUID=501
-      - PGID=20
-      - TZ=Europe/London
-    volumes:
-      - jellyfin-config:/config
-      - jellyfin-cache:/cache
-      - ${DRIVE_PATH:-/Volumes/HomeServer}/Media/Movies:/media/movies:ro
-      - ${DRIVE_PATH:-/Volumes/HomeServer}/Media/TV:/media/tv:ro
-      - ${DRIVE_PATH:-/Volumes/HomeServer}/Media/Anime/Movies:/media/anime-movies:ro
-      - ${DRIVE_PATH:-/Volumes/HomeServer}/Media/Anime/Series:/media/anime-series:ro
-      - ${DRIVE_PATH:-/Volumes/HomeServer}/Media/Music:/media/music:ro
-    ports:
-      - "8096:8096"
-    networks:
-      - homeserver
-    restart: unless-stopped
-    healthcheck:
-      test: ["CMD", "curl", "-f", "http://127.0.0.1:8096/health"]
-      interval: 30s
-      timeout: 10s
-      retries: 3
-      start_period: 30s
+  # NOTE: Jellyfin runs as the NATIVE macOS app (/Applications/Jellyfin.app) on the host,
+  # NOT a container — the Linux image can't use Apple VideoToolbox for hardware transcode.
+  # It serves host port 8096 directly; Butler reaches it via host.docker.internal:8096.
+  # (Retired the container 2026-05-25.)
 
   radarr:
     image: lscr.io/linuxserver/radarr:6.0.4
@@ -126,10 +104,6 @@ networks:
     external: true
 
 volumes:
-  jellyfin-config:
-    name: jellyfin-config
-  jellyfin-cache:
-    name: jellyfin-cache
   radarr-config:
     name: radarr-config
   sonarr-config:

--- a/registry/REGISTRY.md
+++ b/registry/REGISTRY.md
@@ -12,11 +12,18 @@ Cloudflare dashboard (domain `noblehaus.uk`) — mirror them here so they're dis
 | Project | Path (server) | Repo (local) | What it is |
 |---|---|---|---|
 | **home-server** | `~/home-server` | `~/random/HomeServer` | Umbrella: butler (AI brain+PWA+voice) + media/photos/books/smart-home/download stacks. Public via `cloudflared`. |
-| **vector-llm** | `~/vector-llm` | `~/random/vector-llm` | Always-on-mic LLM brain for the Anki Vector robot. Runs as a **host Python process** (`python src/main.py`): host mic → faster-whisper STT → Ollama (qwen) → Kokoro TTS; escalates to butler; shares Postgres as user `vector-robot`. Its compose **provides the `ollama` container** (:11434). |
+| **vector-llm** | `~/vector-llm` | `~/random/vector-llm` | Always-on-mic LLM brain for the Anki Vector robot. Runs as a **host Python process** (`python src/main.py`): host mic → faster-whisper STT → Ollama (qwen) → Kokoro TTS; escalates to butler; shares Postgres as user `vector-robot`. Its compose **provides the `ollama` container** (:11434). **Paused 2026-05-25** — host process stopped. |
 | **claude-esp** | gateway → `~/home-server`-net | `~/random/claude-esp` | ESP32 AMOLED voice device. `esp-gateway` (:8770) bridges device ↔ Groq STT ↔ butler ↔ Kokoro; Claude draws cards via `display_on_device`. *(gateway not yet deployed)* |
 | **dont-lie** | `~/dont-lie` | — | Containerised web app: nginx serving a JS app on **:3001** (`dont-lie-app`), on the `homeserver` net. **Purpose not documented in-repo (no README/description) — owner to confirm.** |
 | **wire-pod-backup** | `~/wire-pod-backup` | — | Backup/escrow data for wire-pod (Anki Vector auth), supporting vector-llm. **Not a running service.** |
 | **gunpey** | `~/gunpey` | — | Local project directory — **no server footprint** (no compose/container, not deployed). |
+
+## Native (host) services — not Docker
+
+| Service | Host port | Notes |
+|---|---|---|
+| **Jellyfin** | `8096` | `/Applications/Jellyfin.app` — runs natively (uses Apple VideoToolbox for HW transcode, which the Linux container can't). Reach from containers via `host.docker.internal:8096`. Container retired 2026-05-25. |
+| **wire-pod** | — | WirePod macOS app (Anki Vector auth/server), supporting vector-llm. |
 
 ## Shared services (the contracts every project should reuse, not duplicate)
 

--- a/registry/services.yaml
+++ b/registry/services.yaml
@@ -54,6 +54,10 @@ services:
     host_port: 8080
 
   # ── home-server: media-stack ─────────────────────────────────────
+  # jellyfin is the NATIVE macOS app (/Applications/Jellyfin.app), NOT a container —
+  # the Linux image can't use Apple VideoToolbox. doctor.sh lists 8096 under
+  # "in registry but NOT live" because it only sees docker ps; that's expected.
+  - { name: jellyfin,    project: home-server, host_port: 8096, native: true }
   - { name: sonarr,      project: home-server, container: sonarr,      host_port: 8989 }
   - { name: radarr,      project: home-server, container: radarr,      host_port: 7878 }
   - { name: bazarr,      project: home-server, container: bazarr,      host_port: 6767 }


### PR DESCRIPTION
## Why
The dashboard showed **Jellyfin down**. Root cause: the Jellyfin **Docker container was stopped** (it can't use Apple VideoToolbox for HW transcode, so playback runs on the **native `/Applications/Jellyfin.app`** instead). But Butler still pointed at the container:
- `server_health.py` probed `http://jellyfin:8096/health` → connection refused → fired `health:jellyfin:down`.
- `butler-api`'s `JELLYFIN_URL=http://jellyfin:8096` → JellyfinTool + user provisioning were **also broken**.

Verified the fix target works: from `butler-api`, `http://host.docker.internal:8096/health` → **HTTP 200** (native app), while `http://jellyfin:8096` errors.

## Changes
- `server_health.py` + `butler-api` `JELLYFIN_URL` → `http://host.docker.internal:8096`
- Remove the `jellyfin` service + orphaned volumes from `docker/media-stack` compose (prevents `compose up` resurrecting it)
- **Registry:** record native Jellyfin on `:8096` (`native: true`) in `services.yaml` + a 'Native (host) services' table in `REGISTRY.md`; note vector-llm paused
- **Docs:** CLAUDE.md (Native Services table) + HOMESERVER_PLAN.md reflect native Jellyfin

## Note
`doctor.sh` only cross-checks `host_port` against `docker ps`, so it will list `8096` under 'in registry but NOT live' — expected, since Jellyfin is native, not a container.